### PR TITLE
Fix bookmarklet button url

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
                     accessing it on any page.
                 </p>
 
-                <a class="bookmarklet" href="#" onclick="javascript:return false;">
+                <a class="bookmarklet" href="javascript:(function(){var%20tota11y=document.createElement('SCRIPT');tota11y.type='text/javascript';tota11y.src='http://khan.github.io/tota11y/tota11y/build/tota11y.min.js';document.getElementsByTagName('head')[0].appendChild(tota11y);})();" onclick="javascript:return false;">
                     tota11y
                 </a>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -10,19 +10,6 @@ document.addEventListener("touchstart", function(e) {
     }
 });
 
-if (/chrome|safari/.test(navigator.userAgent.toLowerCase())) {
-    // Load the bookmarklet
-    var request = new XMLHttpRequest();
-    request.open("GET", "./js/tota11y.min.js", true);
-
-    request.onload = function() {
-        if (request.status >= 200 && request.status < 400) {
-            var bookmarklet = "javascript:" + encodeURI(request.responseText);
-            document.querySelector(".bookmarklet").href = bookmarklet;
-        }
-    };
-
-    request.send();
-} else {
+if (!/chrome|safari/.test(navigator.userAgent.toLowerCase())) {
     document.querySelector(".bookmarklet-container").style.display = "none";
 }

--- a/js/script.js
+++ b/js/script.js
@@ -9,7 +9,3 @@ document.addEventListener("touchstart", function(e) {
         heading.classList.add("touching");
     }
 });
-
-if (!/chrome|safari/.test(navigator.userAgent.toLowerCase())) {
-    document.querySelector(".bookmarklet-container").style.display = "none";
-}


### PR DESCRIPTION
The href url for the [bookmarklet button](http://khan.github.io/tota11y/#Installation) doesn't work: It's currently set to "#" but it should probably be something like this:

    javascript:(function(){var%20tota11y=document.createElement('SCRIPT');tota11y.type='text/javascript';tota11y.src='http://khan.github.io/tota11y/tota11y/build/tota11y.min.js';document.getElementsByTagName('head')[0].appendChild(tota11y);})();