### PR TITLE
Added image alt-text detection to the link text plugin - Fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ class Toolbar {
 }
 
 $(function() {
+    // Attach the global `axs` object from Accessibility Developer Tools to $
+    $.axs = axs;
+
     var bar = new Toolbar();
 
     // TODO: Make this customizable

--- a/less/base.less
+++ b/less/base.less
@@ -56,6 +56,11 @@
         padding: 1px;
     }
 
+    i,
+    em {
+        font-style: italic;
+    }
+
     p {
         margin: 0 0 10px;
     }

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -20,27 +20,90 @@ class LinkTextPlugin extends Plugin {
         `;
     }
 
-    run() {
-        let test = audit("linkWithUnclearPurpose");
+    /**
+     * Slightly modified unclear text checking that has been refactored into
+     * a single method to be called with arbitrary strings.
+     *
+     * Original: https://github.com/GoogleChrome/accessibility-developer-tools/blob/9183b21cb0a02f5f04928f5cb7cb339b6bbc9ff8/src/audits/LinkWithUnclearPurpose.js#L55-67
+     */
+    isDescriptiveText(textContent) {
+        textContent = textContent.replace(/[^a-zA-Z ]/g, '');
+        let stopWords = [
+            'click', 'tap', 'go', 'here', 'learn', 'more', 'this', 'page',
+            'link', 'about'
+        ];
 
-        if (test.result === "FAIL") {
-            test.elements.forEach((el) => {
-                let $el = $(el);
-                let description = `
-                    The text <i>"${$el.text()}"</i> is unclear without context
-                    and may be confusing to screen readers. Consider
-                    rearranging the <code>&lt;a&gt;&lt;/a&gt;</code> tags or
-                    including special screen reader text.
-                `;
-                // TODO: A "show me how" link may be even more helpful
-
-                let entry = this.error(
-                    "Link text is unclear", description, $el);
-
-                annotate.errorLabel(
-                    $el, "", `Link text "${$el.text()}" is unclear`, entry);
-            });
+        for (let i = 0; i < stopWords.length; i++) {
+            let stopwordRE = new RegExp('\\b' + stopWords[i] + '\\b', 'ig');
+            textContent = textContent.replace(stopwordRE, '');
+            if (textContent.trim() == '')
+                return false;
         }
+
+        return true;
+    }
+
+    /**
+     * Checks whether or not the text content of an element (including things
+     * like `aria-label`) is unclear.
+     */
+    validateTextContent(el) {
+        let textContent = $.axs.properties.getTextFromDescendantContent(el);
+        return {
+            textContent: textContent,
+            result: this.isDescriptiveText(textContent),
+        };
+    }
+
+    /**
+     * Checks if an image has descriptive alt text. This is used to determine
+     * whether or not image links (<a> tags with a single <img> descendant)
+     * are unclear.
+     */
+    validateAltText(el) {
+        let altTextContent = el.getAttribute("alt");
+        return {
+            textContent: altTextContent,
+            result: this.isDescriptiveText(altTextContent),
+        };
+    }
+
+    reportError($el, unclearText) {
+        let description = `
+            The text <i>"${unclearText}"</i> is unclear without context and
+            may be confusing to screen readers. Consider rearranging the
+            <code>&lt;a&gt;&lt;/a&gt;</code> tags or including special screen
+            reader text.
+        `;
+        // TODO: A "show me how" link may be even more helpful
+
+        let entry = this.error(
+            "Link text is unclear", description, $el);
+
+        annotate.errorLabel(
+            $el, "", `Link text "${unclearText}" is unclear`, entry);
+    }
+
+    run() {
+        $("a").each((i, el) => {
+            let $el = $(el);
+            if ($el.parents(".tota11y").length) {
+                return;
+            }
+
+            let report;
+            // If this anchor contains a single image, we will test the
+            // clarity of that image's alt text.
+            if ($el.find("> img").length === 1) {
+                report = this.validateAltText($el.find("> img")[0]);
+            } else {
+                report = this.validateTextContent(el);
+            }
+
+            if (!report.result) {
+                this.reportError($el, report.textContent);
+            }
+        });
     }
 
     cleanup() {

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -68,40 +68,49 @@ class LinkTextPlugin extends Plugin {
         };
     }
 
-    reportError($el, unclearText) {
-        let description = `
-            The text <i>"${unclearText}"</i> is unclear without context and
-            may be confusing to screen readers. Consider rearranging the
-            <code>&lt;a&gt;&lt;/a&gt;</code> tags or including special screen
-            reader text.
-        `;
-        // TODO: A "show me how" link may be even more helpful
-
-        let entry = this.error(
-            "Link text is unclear", description, $el);
-
-        annotate.errorLabel(
-            $el, "", `Link text "${unclearText}" is unclear`, entry);
+    reportError($el, description, textContent) {
+        let entry = this.error("Link text is unclear", description, $el);
+        annotate.errorLabel($el, "",
+            `Link text "${textContent}" is unclear`, entry);
     }
 
     run() {
         $("a").each((i, el) => {
             let $el = $(el);
+
+            // Ignore the tota11y UI
             if ($el.parents(".tota11y").length) {
                 return;
             }
 
-            let report;
             // If this anchor contains a single image, we will test the
             // clarity of that image's alt text.
             if ($el.find("> img").length === 1) {
-                report = this.validateAltText($el.find("> img")[0]);
-            } else {
-                report = this.validateTextContent(el);
-            }
+                let report = this.validateAltText($el.find("> img")[0]);
 
-            if (!report.result) {
-                this.reportError($el, report.textContent);
+                if (!report.result) {
+                    let description = `
+                        The alt text for this link's image,
+                        <i>"${report.textContent}"</i>, is unclear without
+                        context and may be confusing to screen readers.
+                        Consider providing more detailed alt text.
+                    `;
+
+                    this.reportError($el, description, report.textContent);
+                }
+            } else {
+                let report = this.validateTextContent(el);
+
+                if (!report.result) {
+                    let description = `
+                        The text <i>"${report.textContent}"</i> is unclear
+                        without context and may be confusing to screen readers.
+                        Consider rearranging the <code>&lt;a&gt;&lt;/a&gt;
+                        </code> tags or including special screen reader text.
+                    `;
+
+                    this.reportError($el, description, report.textContent);
+                }
             }
         });
     }

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -26,21 +26,21 @@ class LinkTextPlugin extends Plugin {
      * Original: https://github.com/GoogleChrome/accessibility-developer-tools/blob/9183b21cb0a02f5f04928f5cb7cb339b6bbc9ff8/src/audits/LinkWithUnclearPurpose.js#L55-67
      */
     isDescriptiveText(textContent) {
-        textContent = textContent.replace(/[^a-zA-Z ]/g, "");
         let stopWords = [
             "click", "tap", "go", "here", "learn", "more", "this", "page",
             "link", "about"
         ];
+        // Generate a regex to match each of the stopWords
+        let stopWordsRE = new RegExp(`\\b(${stopWords.join("|")})\\b`, "ig");
 
-        for (let i = 0; i < stopWords.length; i++) {
-            let stopwordRE = new RegExp("\\b" + stopWords[i] + "\\b", "ig");
-            textContent = textContent.replace(stopwordRE, "");
-            if (textContent.trim() === "") {
-                return false;
-            }
-        }
+        textContent = textContent
+            // Strip leading non-alphabetical characters
+            .replace(/[^a-zA-Z ]/g, "")
+            // Remove the stopWords
+            .replace(stopWordsRE, "");
 
-        return true;
+        // Return whether or not there is any text left
+        return textContent.trim() !== "";
     }
 
     /**

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -6,7 +6,6 @@
 let $ = require("jquery");
 let Plugin = require("../base");
 let annotate = require("../shared/annotate")("link-text");
-let audit = require("../shared/audit");
 
 class LinkTextPlugin extends Plugin {
     getTitle() {
@@ -27,17 +26,18 @@ class LinkTextPlugin extends Plugin {
      * Original: https://github.com/GoogleChrome/accessibility-developer-tools/blob/9183b21cb0a02f5f04928f5cb7cb339b6bbc9ff8/src/audits/LinkWithUnclearPurpose.js#L55-67
      */
     isDescriptiveText(textContent) {
-        textContent = textContent.replace(/[^a-zA-Z ]/g, '');
+        textContent = textContent.replace(/[^a-zA-Z ]/g, "");
         let stopWords = [
-            'click', 'tap', 'go', 'here', 'learn', 'more', 'this', 'page',
-            'link', 'about'
+            "click", "tap", "go", "here", "learn", "more", "this", "page",
+            "link", "about"
         ];
 
         for (let i = 0; i < stopWords.length; i++) {
-            let stopwordRE = new RegExp('\\b' + stopWords[i] + '\\b', 'ig');
-            textContent = textContent.replace(stopwordRE, '');
-            if (textContent.trim() == '')
+            let stopwordRE = new RegExp("\\b" + stopWords[i] + "\\b", "ig");
+            textContent = textContent.replace(stopwordRE, "");
+            if (textContent.trim() === "") {
                 return false;
+            }
         }
 
         return true;

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -48,10 +48,10 @@ class LinkTextPlugin extends Plugin {
      * like `aria-label`) is unclear.
      */
     validateTextContent(el) {
-        let textContent = $.axs.properties.getTextFromDescendantContent(el);
+        let extractedText = $.axs.properties.getTextFromDescendantContent(el);
         return {
-            textContent: textContent,
-            result: this.isDescriptiveText(textContent),
+            extractedText: extractedText,
+            result: this.isDescriptiveText(extractedText),
         };
     }
 
@@ -61,17 +61,17 @@ class LinkTextPlugin extends Plugin {
      * are unclear.
      */
     validateAltText(el) {
-        let altTextContent = el.getAttribute("alt");
+        let altText = el.getAttribute("alt");
         return {
-            textContent: altTextContent,
-            result: this.isDescriptiveText(altTextContent),
+            extractedText: altText,
+            result: this.isDescriptiveText(altText),
         };
     }
 
-    reportError($el, description, textContent) {
+    reportError($el, description, content) {
         let entry = this.error("Link text is unclear", description, $el);
         annotate.errorLabel($el, "",
-            `Link text "${textContent}" is unclear`, entry);
+            `Link text "${content}" is unclear`, entry);
     }
 
     run() {
@@ -91,25 +91,25 @@ class LinkTextPlugin extends Plugin {
                 if (!report.result) {
                     let description = `
                         The alt text for this link's image,
-                        <i>"${report.textContent}"</i>, is unclear without
+                        <i>"${report.extractedText}"</i>, is unclear without
                         context and may be confusing to screen readers.
                         Consider providing more detailed alt text.
                     `;
 
-                    this.reportError($el, description, report.textContent);
+                    this.reportError($el, description, report.extractedText);
                 }
             } else {
                 let report = this.validateTextContent(el);
 
                 if (!report.result) {
                     let description = `
-                        The text <i>"${report.textContent}"</i> is unclear
+                        The text <i>"${report.extractedText}"</i> is unclear
                         without context and may be confusing to screen readers.
                         Consider rearranging the <code>&lt;a&gt;&lt;/a&gt;
                         </code> tags or including special screen reader text.
                     `;
 
-                    this.reportError($el, description, report.textContent);
+                    this.reportError($el, description, report.extractedText);
                 }
             }
         });

--- a/test/index.html
+++ b/test/index.html
@@ -53,6 +53,14 @@
                 <img width="40px" height="40px" src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" role="presentation">
                 <img width="40px" height="40px" src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256">
             </p>
+
+            <p>
+                <a href="http://khan.github.io/tota11y">
+                    <img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67" alt="About this page" width="50">
+                </a>
+                <a href="http://khan.github.io/tota11y">
+                    <img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67" alt="Check out tota11y" width="50">
+                </a>
         </div>
     </div>
 

--- a/test/link-text-test.js
+++ b/test/link-text-test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for the "Link text" plugin
+ */
+
+let assert = require("assert");
+let mockDom = require("./mock-dom");
+
+describe("Link text plugin", function() {
+    let dom = null;
+    let plugin = null;
+
+    before(function(done) {
+        mockDom.createDom(function(domObj) {
+            // Assign `dom` to the object returned by createDom, which allows
+            // us to set the HTML of the virtual environment, query it, and
+            // close the window.
+            dom = domObj;
+
+            let LinkTextPlugin = require("../plugins/link-text");
+            plugin = new LinkTextPlugin();
+
+            done();
+        });
+    });
+
+    it("should not label descriptive links", function() {
+        dom.setHTML(`
+            <a href="#" id="good-link">
+                This is a descriptive link
+            </a>
+        `);
+
+        plugin.run();
+
+        assert(!dom.$("#good-link").hasLabel());
+    });
+
+    it("should label unclear links", function() {
+        dom.setHTML(`
+            <a href="#" id="bad-link">Click here</a> to learn more about
+            dinosaurs. You can also <a id="better-link" href="#">
+            check out my blog</a>.
+        `);
+
+        plugin.run();
+
+        assert(dom.$("#bad-link").hasLabel());
+        assert(!dom.$("#better-link").hasLabel());
+    });
+
+    it("should consider alt text as link text", function() {
+        dom.setHTML(`
+            <a href="#" id="logo-link">
+                <img src="/images/logo.png" alt="Our logo" />
+            </a>
+        `);
+
+        plugin.run();
+
+        // TODO: Test the extended error messages for the presence of "alt"
+        assert(!dom.$("#logo-link").hasLabel());
+    });
+
+    it("should fail on image links with unclear alt text", function() {
+        dom.setHTML(`
+            <a href="#" id="bad-image-link">
+                <img src="/images/banner.png" alt="Click here" />
+            </a>
+        `);
+
+        plugin.run();
+
+        assert(dom.$("#bad-image-link").hasLabel());
+    });
+
+    after(function() {
+        dom.destroy();
+    });
+});

--- a/test/mock-dom/index.js
+++ b/test/mock-dom/index.js
@@ -20,6 +20,9 @@ let jsdom = require("jsdom");
 let m = require("module");
 let annotateStub = require("./annotate-stub");
 
+let axsSrc = fs.readFileSync(
+    "./node_modules/accessibility-developer-tools/dist/js/axs_testing.js",
+    "utf-8");
 let jquerySrc = fs.readFileSync(
     "./node_modules/jquery/dist/jquery.min.js", "utf-8");
 let jqueryExtSrc = fs.readFileSync(
@@ -30,7 +33,7 @@ exports.createDom = function(callback) {
     // JavaScript on the page.
     jsdom.env({
         html: "",
-        src: [jquerySrc, jqueryExtSrc],
+        src: [axsSrc, jquerySrc, jqueryExtSrc],
         done: function(errors, window) {
             // Overwrite the default module loader.
             //

--- a/test/mock-dom/jquery-extensions.js
+++ b/test/mock-dom/jquery-extensions.js
@@ -22,3 +22,6 @@ $.fn.labelText = function() {
 $.fn.expandedText = function() {
     return $(this).data("expanded-text");
 };
+
+// Bind the global `axs` object from Accessibility Developer Tools to jQuery
+$.axs = window.axs;


### PR DESCRIPTION
Hey @MichelleTodd & @rileyjshaw,

I'm going to try GitHub code reviews so that fixes are more out in the open - consider this an experiment. This is also an open invitation to anyone watching: feel free comment inline with any questions or concerns!

I've essentially rewritten the link text plugin to fix #1 (via https://github.com/GoogleChrome/accessibility-developer-tools/issues/156), so now if a link contains a single image, we validate that image's alt text instead of it's text content.

There are some unit tests here as well, which you can confirm with `npm test` (travis will also do it for you). You'll notice the `LinkTextPlugin` now accesses the `axs` global with `$.axs`. This makes testing a bit easier, and I'll continue this pattern going forward. Plugins using just `axs` won't pass any tests.

If you'd like to test manually, run `npm live-test` and activate the Link text plugin. You'll see an image highlighted because it's alt-text is not very good, and it is the only element of a link.