### PR TITLE
Make error descriptions selectable

### DIFF
--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -11,5 +11,5 @@
             {{{title}}}
         </div>
     </a>
-    <div class="tota11y-info-error-description">{{{description}}}</div>
+    <div class="tota11y-info-error-description tota11y-collapsed">{{{description}}}</div>
 </li>

--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -10,6 +10,6 @@
             </span>
             {{{title}}}
         </div>
-        <div class="tota11y-info-error-description">{{{description}}}</div>
     </a>
+	<div class="tota11y-info-error-description">{{{description}}}</div>
 </li>

--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -11,5 +11,5 @@
             {{{title}}}
         </div>
     </a>
-	<div class="tota11y-info-error-description">{{{description}}}</div>
+    <div class="tota11y-info-error-description">{{{description}}}</div>
 </li>

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -250,7 +250,7 @@ class InfoPanel {
                     $(document).scrollTop(error.$el.offset().top - 80);
                 });
 
-                // Collapse the violation if not first
+                // Expand the first violation
                 if (i === 0) {
                     $desc.toggleClass(COLLAPSED_CLASS_NAME);
                     $trigger.toggleClass(COLLAPSED_CLASS_NAME);

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -250,8 +250,9 @@ class InfoPanel {
                     $(document).scrollTop(error.$el.offset().top - 80);
                 });
 
-                // Expand the first violation
+                // Collapse the violation if not first
                 if (i === 0) {
+                    $desc.toggleClass(COLLAPSED_CLASS_NAME);
                     $trigger.toggleClass(COLLAPSED_CLASS_NAME);
                 }
 

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -207,10 +207,13 @@ class InfoPanel {
 
                 // Wire up the expand/collapse trigger
                 let $trigger = $error.find(".tota11y-info-error-trigger");
+				let $desc = $error.find(".tota11y-info-error-description");
+
                 $trigger.click((e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     $trigger.toggleClass(COLLAPSED_CLASS_NAME);
+					$desc.toggleClass(COLLAPSED_CLASS_NAME);
                 });
 
                 // Attach a function to the original error object to open

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -207,13 +207,13 @@ class InfoPanel {
 
                 // Wire up the expand/collapse trigger
                 let $trigger = $error.find(".tota11y-info-error-trigger");
-				let $desc = $error.find(".tota11y-info-error-description");
+                let $desc = $error.find(".tota11y-info-error-description");
 
                 $trigger.click((e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     $trigger.toggleClass(COLLAPSED_CLASS_NAME);
-					$desc.toggleClass(COLLAPSED_CLASS_NAME);
+                    $desc.toggleClass(COLLAPSED_CLASS_NAME);
                 });
 
                 // Attach a function to the original error object to open

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -173,7 +173,7 @@
             font-size: @descriptionFontSize;
             padding: 10px 0 0;
         }
-        &-trigger.tota11y-collapsed &-description {
+        &-description.tota11y-collapsed {
             display: none;
         }
     }

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -172,11 +172,11 @@
         &-description {
             font-size: @descriptionFontSize;
             padding: 10px 0 0;
-			user-select: text;
+            user-select: text;
 
-			&.tota11y-collapsed {
-				display: none;
-			}
+            &.tota11y-collapsed {
+            display: none
+            }
         }
 
     }

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -172,10 +172,13 @@
         &-description {
             font-size: @descriptionFontSize;
             padding: 10px 0 0;
+			user-select: text;
+
+			&.tota11y-collapsed {
+				display: none;
+			}
         }
-        &-description.tota11y-collapsed {
-            display: none;
-        }
+
     }
 
     &-error-count {

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -175,7 +175,7 @@
             user-select: text;
 
             &.tota11y-collapsed {
-            display: none
+                display: none
             }
         }
 


### PR DESCRIPTION
Removed collapse trigger from descriptions, and overrode `user-select` value.