### PR TITLE
Color Blindness Contrast

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "script-loader": "^0.6.1",
     "style-loader": "^0.10.1",
     "webpack": "^1.8.4",
-    "webpack-dev-server": "^1.9.0"
+    "webpack-dev-server": "^1.9.0",
+    "color-blind": "^0.1.0"
   },
   "scripts": {
     "build": "npm run prod && npm run dev",

--- a/plugins/cbcontrast/error-description.handlebars
+++ b/plugins/cbcontrast/error-description.handlebars
@@ -1,0 +1,11 @@
+<p>
+    The color combination
+    <span class="tota11y-color-hexes">{{fgColorHex}}/{{bgColorHex}}</span>
+    has a contrast ratio of <strong>{{contrastRatio}}</strong>, which is not
+    sufficient for {{blindness}} users. At this size, you will need a ratio of at
+    least <strong>{{requiredRatio}}</strong>.
+</p>
+
+<p>
+    Consider using the following foreground/background combination:
+</p>

--- a/plugins/cbcontrast/error-description.handlebars
+++ b/plugins/cbcontrast/error-description.handlebars
@@ -5,7 +5,3 @@
     sufficient for {{blindness}} users. At this size, you will need a ratio of at
     least <strong>{{requiredRatio}}</strong>.
 </p>
-
-<p>
-    Consider using the following foreground/background combination:
-</p>

--- a/plugins/cbcontrast/error-title.handlebars
+++ b/plugins/cbcontrast/error-title.handlebars
@@ -1,0 +1,8 @@
+Insufficient contrast ratio (
+<div class="tota11y-blindness tota11y-{{blindness}}" title="{{blindness}}"></div> {{contrastRatio}} &lt; {{requiredRatio}})
+
+<span class="tota11y-swatches">
+    <span class="tota11y-swatch" style="background-color: {{fgColorHex}}"></span>
+    /
+    <span class="tota11y-swatch" style="background-color: {{bgColorHex}}"></span>
+</span>

--- a/plugins/cbcontrast/index.js
+++ b/plugins/cbcontrast/index.js
@@ -1,0 +1,172 @@
+/**
+ * A plugin to label different levels of contrast on the page, and highlight
+ * those with poor contrast for color blind users.
+ */
+
+let $ = require("jquery");
+let Plugin = require("../base");
+let annotate = require("../shared/annotate")("labels");
+let blinder = require("color-blind/lib/blind").Blind;
+
+let titleTemplate = require("./error-title.handlebars");
+let descriptionTemplate = require("./error-description.handlebars");
+
+require("./style.less");
+
+class ColorBlindContrastPlugin extends Plugin {
+    getTitle() {
+        return "Color Blind Contrast";
+    }
+
+    getDescription() {
+        return "Labels elements with insufficient contrast for color blind users";
+    }
+
+    addError({fgColor, bgColor, blindness, contrastRatio, requiredRatio}, el) {
+
+        let templateData = {
+            fgColorHex: axs.utils.colorToString(fgColor),
+            bgColorHex: axs.utils.colorToString(bgColor),
+            contrastRatio: contrastRatio,
+            requiredRatio: requiredRatio,
+            blindness: blindness
+        };
+
+        return this.error(
+            titleTemplate(templateData),
+            descriptionTemplate(templateData),
+            $(el));
+    }
+
+    blind(color, blindness) {
+        let alpha = color.alpha;
+        color = blinder({
+            R: color.red,
+            G: color.green,
+            B: color.blue
+        }, blindness, false);
+        return {
+            red: color.R | 0,
+            green: color.G | 0,
+            blue: color.B | 0,
+            alpha: alpha
+        };
+    }
+
+    runOneType(el, combinations, fgColor, bgColor, style, blindness, blindnessName) {
+        // Calculate required ratio based on size
+        // Using strings to prevent rounding
+        let requiredRatio = axs.utils.isLargeFont(style) ?
+            "3.0" : "4.5";
+
+        // Build a key for our `combinations` map and report the color
+        // if we have not seen it yet
+        let key = axs.utils.colorToString(fgColor) + "/" +
+                    axs.utils.colorToString(bgColor) + "/" +
+                    blindness + "/" +
+                    requiredRatio;
+
+        fgColor = this.blind(fgColor, blindness);
+        bgColor = this.blind(bgColor, blindness);
+        let contrastRatio = axs.utils.calculateContrastRatio(
+            fgColor, bgColor).toFixed(2);
+
+        if (!axs.utils.isLowContrast(contrastRatio, style)) {
+            // For acceptable contrast values, we don't show ratios if
+            // they have been presented already
+            if (!combinations[key]) {
+                annotate
+                    .label($(el), contrastRatio)
+                    .addClass("tota11y-label-success");
+
+                // Add the key to the combinations map. We don't have an
+                // error to associate it with, so we'll just give it the
+                // value of `true`.
+                combinations[key] = true;
+            }
+        } else {
+            if (!combinations[key]) {
+                // We do not show duplicates in the errors panel, however,
+                // to keep the output from being overwhelming
+                let error = this.addError(
+                    {fgColor, bgColor, blindness: blindnessName, contrastRatio, requiredRatio},
+                    el);
+
+                combinations[key] = error;
+            }
+
+            // We display errors multiple times for emphasis. Each error
+            // will point back to the entry in the info panel for that
+            // particular color combination.
+            //
+            // TODO: The error entry in the info panel will only highlight
+            // the first element with that color combination
+            annotate.errorLabel(
+                $(el),
+                contrastRatio,
+                "This contrast is insufficient at this size.",
+                combinations[key]);
+        }
+    }
+
+    run() {
+        // Temporary parseColor proxy for FF, which offers "transparent" as a
+        // default computed backgroundColor instead of `rgba(0, 0, 0, 0)`.
+        //
+        // https://github.com/GoogleChrome/accessibility-developer-tools/issues/180
+        const _parseColor = axs.utils.parseColor;
+        axs.utils.parseColor = function(colorString) {
+            if (colorString === "transparent") {
+                return new axs.utils.Color(0, 0, 0, 0);
+            } else {
+                return _parseColor(colorString);
+            }
+        };
+
+        // A map of fg/bg color pairs that we have already seen to the error
+        // entry currently present in the info panel
+        let combinations = {};
+
+        // [<internal name>, <name used on UI and in styles>]
+        let blindnesses = [
+            ["protan", "protanopia"],
+            ["deutan", "deuteranopia"],
+            ["tritan", "tritanopia"]
+        ];
+
+        $("*").each((i, el) => {
+            // Only check elements with a direct text descendant
+            if (!axs.properties.hasDirectTextDescendant(el)) {
+                return;
+            }
+
+            // Ignore elements that are part of the tota11y UI
+            if ($(el).parents(".tota11y").length > 0) {
+                return;
+            }
+
+            // Ignore invisible elements
+            if (axs.utils.elementIsTransparent(el) ||
+                axs.utils.elementHasZeroArea(el)) {
+                    return;
+            }
+
+            let style = getComputedStyle(el);
+            let bgColor = axs.utils.getBgColor(style, el);
+            let fgColor = axs.utils.getFgColor(style, el, bgColor);
+
+            for (var blindness of blindnesses) {
+                this.runOneType(el, combinations, fgColor, bgColor, style, blindness[0], blindness[1]);
+            }
+        });
+
+        // Restore the original `parseColor` method
+        axs.utils.parseColor = _parseColor;
+    }
+
+    cleanup() {
+        annotate.removeAll();
+    }
+}
+
+module.exports = ColorBlindContrastPlugin;

--- a/plugins/cbcontrast/style.less
+++ b/plugins/cbcontrast/style.less
@@ -1,0 +1,61 @@
+.tota11y-swatches {
+    margin-left: 5px;
+    margin-right: 5px;
+    position: relative;
+    top: 1px;
+}
+
+.tota11y-swatch {
+    @size: 12px;
+    border: 1px solid #000;
+    display: inline-block;
+    height: @size;
+    width: @size;
+}
+
+.tota11y-color-hexes {
+    font-family: monospace;
+}
+
+.tota11y-blindness-base() {
+    content: "";
+    border-radius: 50%;
+    width: 5px !important;
+    height: 5px !important;
+    position: relative;
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    display: block;
+}
+
+.tota11y-blindness {
+    .tota11y-blindness-base;
+    display: inline-block;
+    margin-right: 6px;
+    background-color: #0F0;
+    
+    &::before {
+        .tota11y-blindness-base;
+        background-color: #00F;
+        left: 2px;
+        top: -6px;
+    }
+    
+    &::after {
+        .tota11y-blindness-base;
+        background-color: #F00;
+        top: -6px;
+        left: 5px;
+    }
+    
+    &.tota11y-protanopia::after {
+      background-color: transparent;
+    }
+    
+    &.tota11y-deuteranopia {
+      background-color: transparent;
+    }
+    
+    &.tota11y-tritanopia::before {
+      background-color: transparent;
+    }
+}

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -5,6 +5,7 @@
  */
 
 let AltTextPlugin = require("./alt-text");
+let ColorBlindContrastPlugin = require("./cbcontrast");
 let ContrastPlugin = require("./contrast");
 let HeadingsPlugin = require("./headings");
 let LabelsPlugin = require("./labels");
@@ -18,4 +19,5 @@ module.exports = [
     new LabelsPlugin(),
     new AltTextPlugin(),
     new LandmarksPlugin(),
+    new ColorBlindContrastPlugin()
 ];


### PR DESCRIPTION
A color blindness contrast plugin that supports protanopia, deuteranopia and tritanopia. Compared to the last PR *all* types of contrast issues are now reported as it is no longer bundled in with the original contrast plugin.

- Adding `color-blind` package.
- Creating templates to display color blindness contrast information.
- Adding `ColorBlindContrastPlugin`.

## Screenshot

![colorblind](https://cloud.githubusercontent.com/assets/522465/8806912/5fe78624-2fd9-11e5-8de0-0450d65f67dc.png)

## Limitations

* There are no suggestions: could look at [daltonization](http://www.daltonize.org/) but that would require a PR on `color-blind` first.
* Anomalous trichromacy is not checked as it is merely a less severe form of dichromacy.