### PR TITLE
Contrast plugin suggestion preview - Fixes #21

### DIFF
--- a/plugins/alt-text/index.js
+++ b/plugins/alt-text/index.js
@@ -39,7 +39,7 @@ class AltTextPlugin extends Plugin {
                 annotate.label($el, "&#x2717;")
                     .addClass("tota11y-label-error");
 
-                this.error("Image is missing alt text", errorTemplate(), $el);
+                this.error("Image is missing alt text", $(errorTemplate()), $el);
             }
         });
     }

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -44,8 +44,8 @@ class Plugin {
     }
 
     // Adds an entry to the info panel's "Errors" tab
-    error(title, description, $el) {
-        return this.panel.addError(title, description, $el);
+    error(title, $description, $el) {
+        return this.panel.addError(title, $description, $el);
     }
 
     /**

--- a/plugins/contrast/error-description.handlebars
+++ b/plugins/contrast/error-description.handlebars
@@ -1,33 +1,33 @@
-<p>
-    The color combination
-    <span class="tota11y-color-hexes">{{fgColorHex}}/{{bgColorHex}}</span>
-    has a contrast ratio of <strong>{{contrastRatio}}</strong>, which is not
-    sufficient. At this size, you will need a ratio of at least
-    <strong>{{requiredRatio}}</strong>.
-</p>
+<div>
+    <p>
+        The color combination
+        <span class="tota11y-color-hexes">{{fgColorHex}}/{{bgColorHex}}</span>
+        has a contrast ratio of <strong>{{contrastRatio}}</strong>, which is not
+        sufficient. At this size, you will need a ratio of at least
+        <strong>{{requiredRatio}}</strong>.
+    </p>
 
-<p>
-    Consider using the following foreground/background combination:
-</p>
+    <p>
+        Consider using the following foreground/background combination:
+    </p>
 
-<div class="tota11y-contrast-suggestion">
-    <span class="tota11y-color-hexes">
-        {{suggestedFgColorHex}}/{{suggestedBgColorHex}}
-    </span>
-
-    <span class="tota11y-swatches">
-        <span
-            class="tota11y-swatch"
-            style="background-color: {{suggestedFgColorHex}}">
+    <div class="tota11y-contrast-suggestion">
+        <span class="tota11y-color-hexes">
+            {{suggestedFgColorHex}}/{{suggestedBgColorHex}}
         </span>
-        /
-        <span
-            class="tota11y-swatch"
-            style="background-color: {{suggestedBgColorHex}}">
+
+        <span class="tota11y-swatches">
+            <span
+                class="tota11y-swatch"
+                style="background-color: {{suggestedFgColorHex}}">
+            </span>
+            /
+            <span
+                class="tota11y-swatch"
+                style="background-color: {{suggestedBgColorHex}}">
+            </span>
         </span>
-    </span>
 
-    has a ratio of
-
-    <strong>{{suggestedColorsRatio}}</strong>
+        has a ratio of <strong>{{suggestedColorsRatio}}</strong> <input class="previewCb" type="checkbox">
+    </div>
 </div>

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -39,9 +39,25 @@ class ContrastPlugin extends Plugin {
             suggestedColorsRatio: suggestedColors.contrast
         };
 
+        let $description = $(descriptionTemplate(templateData));
+
+        // Add click handler to preview checkbox.
+        $description.find(".previewCb").click(function() {
+            console.log("Checkbox changed");
+            /*if(this.checked) {
+                // Set suggested colors.
+                $(el).css('color', suggestedColors.fg);
+                $(el).css('background-color', suggestedColors.bg);
+            } else {
+                // Set original colors.
+                $(el).css('color', fgColor);
+                $(el).css('background-color', bgColor);
+            }*/
+        });
+
         return this.error(
             titleTemplate(templateData),
-            descriptionTemplate(templateData),
+            $description.html(),
             $(el));
     }
 

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -25,8 +25,7 @@ class ContrastPlugin extends Plugin {
         // Suggest colors at an "AA" level
         let suggestedColors = axs.utils.suggestColors(
             bgColor,
-            fgColor,
-            contrastRatio,
+            fgColor, contrastRatio,
             getComputedStyle(el)).AA;
 
         let templateData = {
@@ -39,25 +38,23 @@ class ContrastPlugin extends Plugin {
             suggestedColorsRatio: suggestedColors.contrast
         };
 
-        let $description = $(descriptionTemplate(templateData));
-
         // Add click handler to preview checkbox.
+        let $description = $(descriptionTemplate(templateData));
         $description.find(".previewCb").click(function() {
-            console.log("Checkbox changed");
-            /*if(this.checked) {
+            if(this.checked) {
                 // Set suggested colors.
                 $(el).css('color', suggestedColors.fg);
                 $(el).css('background-color', suggestedColors.bg);
             } else {
                 // Set original colors.
-                $(el).css('color', fgColor);
-                $(el).css('background-color', bgColor);
-            }*/
+                $(el).css('color', axs.utils.colorToString(fgColor));
+                $(el).css('background-color', axs.utils.colorToString(bgColor));
+            }
         });
 
         return this.error(
             titleTemplate(templateData),
-            $description.html(),
+            $description,
             $(el));
     }
 

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -13,6 +13,7 @@ let descriptionTemplate = require("./error-description.handlebars");
 require("./style.less");
 
 class ContrastPlugin extends Plugin {
+
     getTitle() {
         return "Contrast";
     }
@@ -76,6 +77,10 @@ class ContrastPlugin extends Plugin {
         // entry currently present in the info panel
         let combinations = {};
 
+        // List of original colors for elements with insufficient contrast.
+        // Used to restore original colors in cleanup.
+        this.origColorsList = [];
+
         $("*").each((i, el) => {
             // Only check elements with a direct text descendant
             if (!axs.properties.hasDirectTextDescendant(el)) {
@@ -131,6 +136,13 @@ class ContrastPlugin extends Plugin {
                         {fgColor, bgColor, contrastRatio, requiredRatio},
                         el);
 
+                    // Save original color so it can be restored on cleanup.
+                    this.origColorsList.push({
+                        $el: $(el),
+                        fg: axs.utils.colorToString(fgColor),
+                        bg: axs.utils.colorToString(bgColor)
+                    });
+
                     combinations[key] = error;
                 }
 
@@ -153,6 +165,12 @@ class ContrastPlugin extends Plugin {
     }
 
     cleanup() {
+        // Set all elements to original color.
+        for(let i = 0; i < this.origColorsList.length; i++) {
+            let item = this.origColorsList[i];
+            item.$el.css('color', item.fg);
+            item.$el.css('background-color', item.bg);
+        }
         annotate.removeAll();
     }
 }

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -44,12 +44,12 @@ class ContrastPlugin extends Plugin {
         $description.find(".previewCb").click(function() {
             if(this.checked) {
                 // Set suggested colors.
-                $(el).css('color', suggestedColors.fg);
-                $(el).css('background-color', suggestedColors.bg);
+                $(el).css("color", suggestedColors.fg);
+                $(el).css("background-color", suggestedColors.bg);
             } else {
                 // Set original colors.
-                $(el).css('color', axs.utils.colorToString(fgColor));
-                $(el).css('background-color', axs.utils.colorToString(bgColor));
+                $(el).css("color", axs.utils.colorToString(fgColor));
+                $(el).css("background-color", axs.utils.colorToString(bgColor));
             }
         });
 
@@ -168,8 +168,8 @@ class ContrastPlugin extends Plugin {
         // Set all elements to original color.
         for(let i = 0; i < this.origColorsList.length; i++) {
             let item = this.origColorsList[i];
-            item.$el.css('color', item.fg);
-            item.$el.css('background-color', item.bg);
+            item.$el.css("color", item.fg);
+            item.$el.css("background-color", item.bg);
         }
         annotate.removeAll();
     }

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -13,7 +13,6 @@ let descriptionTemplate = require("./error-description.handlebars");
 require("./style.less");
 
 class ContrastPlugin extends Plugin {
-
     getTitle() {
         return "Contrast";
     }
@@ -26,7 +25,8 @@ class ContrastPlugin extends Plugin {
         // Suggest colors at an "AA" level
         let suggestedColors = axs.utils.suggestColors(
             bgColor,
-            fgColor, contrastRatio,
+            fgColor,
+            contrastRatio,
             getComputedStyle(el)).AA;
 
         let templateData = {
@@ -42,7 +42,7 @@ class ContrastPlugin extends Plugin {
         // Add click handler to preview checkbox.
         let $description = $(descriptionTemplate(templateData));
         $description.find(".previewCb").click(function() {
-            if(this.checked) {
+            if (this.checked) {
                 // Set suggested colors.
                 $(el).css("color", suggestedColors.fg);
                 $(el).css("background-color", suggestedColors.bg);

--- a/plugins/headings/index.js
+++ b/plugins/headings/index.js
@@ -109,7 +109,7 @@ class HeadingsPlugin extends Plugin {
             if (error) {
                 // Register an error to the info panel
                 let infoPanelError = this.error(
-                    error.title, error.description, $el);
+                    error.title, $(error.description), $el);
 
                 // Place an error label on the heading tag
                 annotate.errorLabel(

--- a/plugins/headings/index.js
+++ b/plugins/headings/index.js
@@ -15,10 +15,12 @@ const ERRORS = {
         return {
             title: "First heading is not an &lt;h1&gt;",
             description: `
-                To give your document a proper structure for assistive
-                technologies, it is important to lay out your headings
-                beginning with an <code>&lt;h1&gt;</code>. We found an
-                <code>&lt;h${level}&gt;</code> instead.
+                <div>
+                    To give your document a proper structure for assistive
+                    technologies, it is important to lay out your headings
+                    beginning with an <code>&lt;h1&gt;</code>. We found an
+                    <code>&lt;h${level}&gt;</code> instead.
+                </div>
             `
         };
     },
@@ -42,11 +44,12 @@ const ERRORS = {
     NONCONSECUTIVE_HEADER(prevLevel, currLevel) {
         let _tag = (level) => `<code>&lt;h${level}&gt;</code>`;
         let description = `
-            This document contains an ${_tag(currLevel)} tag directly
-            following an ${_tag(prevLevel)}. In order to maintain a consistent
-            outline of the page for assistive technologies, reduce the gap in
-            the heading level by upgrading this tag to an
-            ${_tag(prevLevel+1)}`;
+            <div>
+                This document contains an ${_tag(currLevel)} tag directly
+                following an ${_tag(prevLevel)}. In order to maintain a consistent
+                outline of the page for assistive technologies, reduce the gap in
+                the heading level by upgrading this tag to an
+                ${_tag(prevLevel+1)}`;
 
         // Suggest upgrading the tag to the same level as `prevLevel` iff
         // `prevLevel` is not 1
@@ -54,12 +57,14 @@ const ERRORS = {
             description += ` or ${_tag(prevLevel)}`;
         }
 
+        description += `.</div>`;
+
         return {
             title: `
                 Nonconsecutive heading level used (h${prevLevel} &rarr;
                 h${currLevel})
             `,
-            description: description + "."
+            description: description
         };
     }
 };

--- a/plugins/labels/index.js
+++ b/plugins/labels/index.js
@@ -36,7 +36,7 @@ class LabelsPlugin extends Plugin {
 
                 // Place an error label on the element and register it as an
                 // error in the info panel
-                let entry = this.error(title, this.errorMessage($el), $el);
+                let entry = this.error(title, $(this.errorMessage($el)), $el);
                 annotate.errorLabel($el, "", title, entry);
             });
         }

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -69,7 +69,7 @@ class LinkTextPlugin extends Plugin {
     }
 
     reportError($el, description, content) {
-        let entry = this.error("Link text is unclear", description, $el);
+        let entry = this.error("Link text is unclear", $(description), $el);
         annotate.errorLabel($el, "",
             `Link text "${content}" is unclear`, entry);
     }

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -90,10 +90,12 @@ class LinkTextPlugin extends Plugin {
 
                 if (!report.result) {
                     let description = `
+                    <div>
                         The alt text for this link's image,
                         <i>"${report.extractedText}"</i>, is unclear without
                         context and may be confusing to screen readers.
                         Consider providing more detailed alt text.
+                    </div>
                     `;
 
                     this.reportError($el, description, report.extractedText);
@@ -103,10 +105,12 @@ class LinkTextPlugin extends Plugin {
 
                 if (!report.result) {
                     let description = `
-                        The text <i>"${report.extractedText}"</i> is unclear
-                        without context and may be confusing to screen readers.
-                        Consider rearranging the <code>&lt;a&gt;&lt;/a&gt;
-                        </code> tags or including special screen reader text.
+                        <div>
+                            The text <i>"${report.extractedText}"</i> is unclear
+                            without context and may be confusing to screen readers.
+                            Consider rearranging the <code>&lt;a&gt;&lt;/a&gt;
+                            </code> tags or including special screen reader text.
+                        </div>
                     `;
 
                     this.reportError($el, description, report.extractedText);

--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -11,5 +11,5 @@
             {{{title}}}
         </div>
     </a>
-    <div class="tota11y-info-error-description tota11y-collapsed">{{{description}}}</div>
+    <div class="tota11y-info-error-description tota11y-collapsed"></div>
 </li>

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -61,8 +61,8 @@ class InfoPanel {
      * Adds an error to the errors tab. Also receives a jQuery element to
      * highlight on hover.
      */
-    addError(title, description, $el) {
-        let error = {title, description, $el};
+    addError(title, $description, $el) {
+        let error = {title, $description, $el};
         this.errors.push(error);
         return error;
     }
@@ -203,6 +203,13 @@ class InfoPanel {
 
             this.errors.forEach((error, i) => {
                 let $error = $(errorTemplate(error));
+
+                // Insert description jQuery object into template.
+                // This is done so functionality can be inserted.
+                let $description = error.$description;
+                $error.find('.tota11y-info-error-description')
+                    .append($description);
+
                 $errors.append($error);
 
                 // Wire up the expand/collapse trigger

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -207,7 +207,7 @@ class InfoPanel {
                 // Insert description jQuery object into template.
                 // This is done so functionality can be inserted.
                 let $description = error.$description;
-                $error.find('.tota11y-info-error-description')
+                $error.find(".tota11y-info-error-description")
                     .append($description);
 
                 $errors.append($error);

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -205,10 +205,11 @@ class InfoPanel {
                 let $error = $(errorTemplate(error));
 
                 // Insert description jQuery object into template.
-                // This is done so functionality can be inserted.
-                let $description = error.$description;
-                $error.find(".tota11y-info-error-description")
-                    .append($description);
+                // Description is passed as jQuery object
+                // so that functionality can be inserted.
+                $error
+                    .find(".tota11y-info-error-description")
+                    .append(error.$description);
 
                 $errors.append($error);
 


### PR DESCRIPTION
This adds a checkbox next to the suggested color combination which will toggle between original colors and suggested colors. In order to embed the functionality for the checkbox I had to modify all plugins to pass their descriptions as jQuery objects (with the blessing of @jdan of course).

It might be worth discussing if there is a better way to represent the control for this than a checkbox; it seemed like the cleanest and simplest way to me but I can see that it might not be very intuitive, especially without a label.