### PR TITLE
Simplified logic for rendering plugins in the tota11y toolbar

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+    "parser": "babel-eslint",
     "env": {
         "node": true,
         "browser": true,
@@ -7,6 +8,7 @@
     },
     "rules": {
         "comma-dangle": 0,
+        "new-cap": 0,
         "no-underscore-dangle": 0,
         "quotes": [2, "double"],
         "space-after-keywords": [2, "always"],

--- a/index.js
+++ b/index.js
@@ -16,6 +16,31 @@ let logoTemplate = require("./templates/logo.handlebars");
 require("script!./node_modules/accessibility-developer-tools/dist/js/axs_testing.js");
 
 class Toolbar {
+    constructor() {
+        this.activePlugin = null;
+    }
+
+    /**
+     * Manages the state of the toolbar when a plugin is clicked, and toggles
+     * the appropriate plugins on and off.
+     */
+    handlePluginClick(plugin) {
+        // If the plugin was already selected, toggle it off
+        if (plugin === this.activePlugin) {
+            plugin.deactivate();
+            this.activePlugin = null;
+        } else {
+            // Deactivate the active plugin if there is one
+            if (this.activePlugin) {
+                this.activePlugin.deactivate();
+            }
+
+            // Activate the selected plugin
+            plugin.activate();
+            this.activePlugin = plugin;
+        }
+    }
+
     /**
      * Renders the toolbar and appends it the specified element.
      */
@@ -23,32 +48,12 @@ class Toolbar {
         let $logo = $(logoTemplate());
         let $toolbar;
 
-        // Manages the state of the toolbar when a plugin is clicked, and
-        // toggles the appropriate plugins
-        let activePlugin = null;
-        let handlePluginClick = (plugin) => {
-            // If the plugin was already selected, toggle it off
-            if (plugin === activePlugin) {
-                plugin.deactivate();
-                activePlugin = null;
-            } else {
-                // Deactivate the active plugin if there is one
-                if (activePlugin) {
-                    activePlugin.deactivate();
-                }
-
-                // Activate the selected plugin
-                plugin.activate();
-                activePlugin = plugin;
-            }
-        };
-
         let $plugins = (
             <div className="tota11y-plugins">
                 {
                     plugins.map((plugin) => {
-                        // Render each plugin with the click handler
-                        return plugin.render(handlePluginClick);
+                        // Render each plugin with the bound click handler
+                        return plugin.render(::this.handlePluginClick);
                     })
                 }
             </div>

--- a/index.js
+++ b/index.js
@@ -16,35 +16,41 @@ let logoTemplate = require("./templates/logo.handlebars");
 require("script!./node_modules/accessibility-developer-tools/dist/js/axs_testing.js");
 
 class Toolbar {
+    /**
+     * Renders the toolbar and appends it the specified element.
+     */
     appendTo($el) {
         let $logo = $(logoTemplate());
         let $toolbar;
 
+        // Manages the state of the toolbar when a plugin is clicked, and
+        // toggles the appropriate plugins
         let activePlugin = null;
         let handlePluginClick = (plugin) => {
+            // If the plugin was already selected, toggle it off
             if (plugin === activePlugin) {
-                plugin.cleanup();
-                plugin.panel.destroy();
-                plugin.$checkbox.attr("checked", false);
-
+                plugin.deactivate();
                 activePlugin = null;
             } else {
+                // Deactivate the active plugin if there is one
                 if (activePlugin) {
-                    activePlugin.cleanup();
-                    activePlugin.panel.destroy();
-                    activePlugin.$checkbox.attr("checked", false);
+                    activePlugin.deactivate();
                 }
 
-                plugin.run();
-                plugin.panel.render();
-
+                // Activate the selected plugin
+                plugin.activate();
                 activePlugin = plugin;
             }
         };
 
         let $plugins = (
             <div className="tota11y-plugins">
-                {plugins.map((plugin) => plugin.render(handlePluginClick))}
+                {
+                    plugins.map((plugin) => {
+                        // Render each plugin with the click handler
+                        return plugin.render(handlePluginClick);
+                    })
+                }
             </div>
         );
 

--- a/index.js
+++ b/index.js
@@ -20,14 +20,35 @@ class Toolbar {
         let $logo = $(logoTemplate());
         let $toolbar;
 
-        // Attach each plugin
-        let $plugins = <div className="tota11y-plugins" />;
-        plugins.forEach((plugin) => {
-            // Mount the plugin to the list
-            plugin.appendTo($plugins);
-        });
+        let activePlugin = null;
+        let handlePluginClick = (plugin) => {
+            if (plugin === activePlugin) {
+                plugin.cleanup();
+                plugin.panel.destroy();
+                plugin.$checkbox.attr("checked", false);
 
-        let handleClick = (e) => {
+                activePlugin = null;
+            } else {
+                if (activePlugin) {
+                    activePlugin.cleanup();
+                    activePlugin.panel.destroy();
+                    activePlugin.$checkbox.attr("checked", false);
+                }
+
+                plugin.run();
+                plugin.panel.render();
+
+                activePlugin = plugin;
+            }
+        };
+
+        let $plugins = (
+            <div className="tota11y-plugins">
+                {plugins.map((plugin) => plugin.render(handlePluginClick))}
+            </div>
+        );
+
+        let handleToggleClick = (e) => {
             e.preventDefault();
             e.stopPropagation();
             $toolbar.toggleClass("tota11y-expanded");
@@ -36,7 +57,7 @@ class Toolbar {
         let $toggle = (
             <a href="#"
                className="tota11y-toolbar-toggle"
-               onClick={handleClick}>
+               onClick={handleToggleClick}>
                 <div className="tota11y-toolbar-logo">
                     {$logo}
                 </div>

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class Toolbar {
     }
 
     /**
-     * Renders the toolbar and appends it the specified element.
+     * Renders the toolbar and appends it to the specified element.
      */
     appendTo($el) {
         let $logo = $(logoTemplate());

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "autoprefixer-loader": "^2.0.0",
     "babel": "^5.6.7",
     "babel-core": "^5.0.12",
+    "babel-eslint": "^3.1.23",
     "babel-loader": "^5.0.0",
     "css-loader": "^0.10.1",
     "eslint": "^0.23.0",

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -12,12 +12,11 @@
 let $ = require("jquery");
 let InfoPanel = require("./shared/info-panel");
 let template = require("../templates/plugin.handlebars");
-let id = 1;
 
 class Plugin {
     constructor() {
-        this.id = id++;
         this.panel = new InfoPanel(this.getTitle());
+        this.$checkbox = null;
     }
 
     getTitle() {
@@ -51,64 +50,21 @@ class Plugin {
     /**
      * Renders the plugin view.
      */
-    render() {
+    render(onClick) {
         let templateData = {
             title: this.getTitle(),
             description: this.getDescription()
         };
 
-        return $(template(templateData));
-    }
+        let $plugin = $(template(templateData));
 
-    /**
-     * Attaches the plugin to a given DOMNode.
-     * (chainable)
-     */
-    appendTo($el) {
-        // Render and mount plugin
-        let $plugin = this.render();
-        $el.append($plugin);
-
-        let $checkbox = $plugin.find(".tota11y-plugin-checkbox");
-
-        $checkbox.click((e) => {
+        this.$checkbox = $plugin.find(".tota11y-plugin-checkbox");
+        this.$checkbox.click((e) => {
             e.stopPropagation();
-
-            // Trigger a `plugin-switched` event on the container, which will
-            // be dispatched to all plugins. We include this plugin's ID to
-            // determine if we should enable or disable the plugin listening
-            // for this event.
-            $el.trigger("plugin-switched", [this.id]);
-
-            // If our checkbox is checked, run and render the panel.
-            // Otherwise, cleanup.
-            if ($checkbox.is(":checked")) {
-                this.run();
-                this.panel.render();
-            } else {
-                this.cleanup();
-                this.panel.destroy();
-            }
+            onClick(this);
         });
 
-        // Listen for the `plugin-switched` event on the plugins container.
-        $el.on("plugin-switched", (e, pluginId) => {
-            // If we are the plugin that the user has interacted with, ignore
-            // this step. We handle our own behavior before the event is
-            // dispatched.
-            if (pluginId === this.id) {
-                return;
-
-            // If we are an active plugin that the user switched from, we
-            // uncheck ourselves and clean up.
-            } else if ($checkbox.is(":checked")) {
-                $checkbox.attr("checked", false);
-                this.cleanup();
-                this.panel.destroy();
-            }
-        });
-
-        return this;
+        return $plugin;
     }
 }
 

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -50,7 +50,7 @@ class Plugin {
     /**
      * Renders the plugin view.
      */
-    render(onClick) {
+    render(clickHandler) {
         let templateData = {
             title: this.getTitle(),
             description: this.getDescription()
@@ -61,10 +61,31 @@ class Plugin {
         this.$checkbox = $plugin.find(".tota11y-plugin-checkbox");
         this.$checkbox.click((e) => {
             e.stopPropagation();
-            onClick(this);
+            clickHandler(this);
         });
 
         return $plugin;
+    }
+
+    /**
+     * Activate the plugin from the UI.
+     */
+    activate() {
+        this.run();
+        this.panel.render();
+    }
+
+    /**
+     * Deactivate the plugin from the UI.
+     */
+    deactivate() {
+        this.cleanup();
+        this.panel.destroy();
+
+        // If we toggle the plugin ourselves, the checkbox will already be
+        // unchecked. If another plugin becomes active, however, this method
+        // will be called and will uncheck the checkbox.
+        this.$checkbox.attr("checked", false);
     }
 }
 

--- a/plugins/headings/index.js
+++ b/plugins/headings/index.js
@@ -9,7 +9,6 @@ let annotate = require("../shared/annotate")("headings");
 let outlineItemTemplate = require("./outline-item.handlebars");
 require("./style.less");
 
-/* eslint new-cap:0 */
 const ERRORS = {
     FIRST_NOT_H1(level) {
         return {

--- a/test/babel-hook.js
+++ b/test/babel-hook.js
@@ -11,6 +11,4 @@ require("babel/register")({
 });
 
 // Store our custom JSX transpile target as a global
-/* global E */
-/* eslint no-unused-vars:0, no-undef:0 */
-E = require("../element.js");
+E = require("../element.js");       // eslint-disable-line no-undef

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
                 query: {
                     // Transpile JSX into calls to "E()"
                     jsxPragma: "E",
+                    optional: ["es7.functionBind"],
                 },
             },
             { test: /\.handlebars$/, loader: "handlebars", },


### PR DESCRIPTION
Hey @MichelleTodd `||` @rileyjshaw,

Previously, tota11y used a strange mechanism for mounting plugins to the toolbar and switching between them on user interaction. After the JSX fun was added in #42, I wanted to try to make plugin rendering more explicit.

This changeset moves the logic for activating/deactivating plugins from the plugins themselves and into the Toolbar module. This allowed me to remove the weird event listener mechanism and swap it for a more straightforward `handlePluginClick` method.