### PR TITLE
Annotation toggling - Fixes #49

### DIFF
--- a/plugins/shared/annotate/index.js
+++ b/plugins/shared/annotate/index.js
@@ -168,6 +168,14 @@ module.exports = (namespace) => {
             });
         },
 
+        hide() {
+            $(".tota11y-label").hide();
+        },
+
+        show() {
+            $(".tota11y-label").show();
+        },
+
         removeAll() {
             // Remove all annotations
             $("." + ANNOTATION_CLASS).remove();

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -197,10 +197,8 @@ class InfoPanel {
         // Wire annotation toggling.
         this.$el.find(".toggle-annotation").click((e) => {
             if ($(e.target).prop("checked")) {
-                // Showing annotations.
                 annotate.show();
             } else {
-                // Hiding annotations.
                 annotate.hide();
             }
         });

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -194,6 +194,17 @@ class InfoPanel {
             $activeTab = this._addTab("Summary", this.summary);
         }
 
+        // Wire annotation toggling.
+        this.$el.find(".toggle-annotation").click((e) => {
+            if ($(e.target).prop("checked")) {
+                // Showing annotations.
+                annotate.show();
+            } else {
+                // Hiding annotations.
+                annotate.hide();
+            }
+        });
+
         if (this.errors.length > 0) {
             let $errors = $("<ul>").addClass("tota11y-info-errors");
 

--- a/plugins/shared/info-panel/template.handlebars
+++ b/plugins/shared/info-panel/template.handlebars
@@ -3,7 +3,7 @@
         {{title}}
         <span class="tota11y-info-dismiss">
             <label>
-                Annotate:
+                Show annotations:
                 <input class="toggle-annotation" type="checkbox" checked>
             </label>
             <a href="#" class="tota11y-info-dismiss-trigger">&times;</a>

--- a/plugins/shared/info-panel/template.handlebars
+++ b/plugins/shared/info-panel/template.handlebars
@@ -2,6 +2,10 @@
     <header class="tota11y-info-title">
         {{title}}
         <span class="tota11y-info-dismiss">
+            <label>
+                Annotate:
+                <input class="toggle-annotation" type="checkbox" checked>
+            </label>
             <a href="#" class="tota11y-info-dismiss-trigger">&times;</a>
         </span>
     </header>


### PR DESCRIPTION
- Add hide/show functions to annotate class.
- Add checkbox on info-panel for enabling/disabling annotations.

I wasn't sure of the best place to put the control for this. I ended up putting it in the header of the info panel, next to the dismiss button. I liked having it on the info panel as it makes it easier to handle the user switching between different plugins. 