### PR TITLE
Make wand plugin cleanup after itself.

### DIFF
--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -44,6 +44,7 @@ class A11yTextWand extends Plugin {
     }
 
     cleanup() {
+        $(".tota11y-outlined").removeClass("tota11y-outlined");
         $(document).off("mousemove.wand");
     }
 }


### PR DESCRIPTION
If you disabled the wand plugin, the currently outlined element would
stay outlined. This change fixes that.