### PR TITLE
Upgrade to accessibility-developer-tools 2.9.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Jordan Scales <scalesjordan@gmail.com>",
   "devDependencies": {
-    "accessibility-developer-tools": "^2.7.0",
+    "accessibility-developer-tools": "2.9.0-rc.0",
     "autoprefixer-loader": "^2.0.0",
     "babel": "^5.6.7",
     "babel-core": "^5.0.12",

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -68,14 +68,6 @@ class LinkTextPlugin extends Plugin {
                 return;
             }
 
-            // Monkey-patch `matchSelector` for our jsdom testing environment,
-            // using jQuery for optimal browser support.
-            //
-            // https://github.com/GoogleChrome/accessibility-developer-tools/pull/189
-            $.axs.browserUtils.matchSelector = (node, selectorText) => {
-                return $(node).is(selectorText);
-            };
-
             // Extract the text alternatives for this element: including
             // its text content, aria-label/labelledby, and alt text for
             // images.

--- a/plugins/shared/audit.js
+++ b/plugins/shared/audit.js
@@ -29,14 +29,6 @@ function createWhitelist(ruleName) {
 // Audits for a single rule (by name) and returns the results for only that
 // rule
 function audit(ruleName) {
-    // Monkey-patch `matchSelector` for our jsdom testing environment,
-    // using jQuery for optimal browser support.
-    //
-    // https://github.com/GoogleChrome/accessibility-developer-tools/pull/189
-    $.axs.browserUtils.matchSelector = (node, selectorText) => {
-        return $(node).is(selectorText);
-    };
-
     let whitelist = createWhitelist(ruleName);
 
     return $.axs.Audit.run(whitelist)


### PR DESCRIPTION
@rileyjshaw && @MichelleTodd,

I've updated `package.json` to use the latest version of Accessibility Developer Tools, which includes a bunch of fixes for which we no longer need workarounds, yay!

I also updated the ContrastPlugin to use the new `axs.color` module.

Test plan:
```
$ npm run live-test
// http://localhost:8080/test/
```

Verify that the contrast plugin works :)