### PR TITLE
Fix color suggestions preview in ContrastPlugin

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -6,6 +6,19 @@
         body {
             font-family: Arial;
         }
+
+        .gradient {
+            background-image: linear-gradient(to bottom, #2937FF 0%, #6EFFCF 100%);
+            padding: 40px;
+            text-align: center;
+            width: 400px;
+        }
+
+        .gradient .text {
+            color: white;
+            font-size: 24px;
+            font-weight: bold;
+        }
     </style>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
 </head>
@@ -61,6 +74,13 @@
                 <a href="http://khan.github.io/tota11y">
                     <img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67" alt="Check out tota11y" width="50">
                 </a>
+            </p>
+
+            <div class="gradient">
+                <div class="text">
+                    This text has a gradient
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
@rileyjshaw,

The "Preview" functionality of the ContrastPlugin (#45) currently works by setting the foreground/background color of the element to ADT's suggestions when activated, then falling back to the *computed* foreground/background colors when deactivated.

The problem with this is that the *computed* fg/bg colors do not work for gradients, and lead to breaking the page like so:

<img width="481" alt="screen shot 2015-09-06 at 9 30 07 pm" src="https://cloud.githubusercontent.com/assets/287268/9707747/c8b175f0-54de-11e5-9c41-1e094b87cae0.png">

In this bug, the background color of the text comes from the gray background that the gradient sits in front of (ADT reads the gradient as "transparent" and chooses the background color behind it).

This change modifies the behavior of the preview function by restoring the foreground/background colors from the elements `getComputedStyle`. In the screenshot above, this means the `<div>` would receive its original `background-color` - transparent - instead of the gray from its ancestor.

Test plan:
. `npm run live-test`
. http://localhost:8080/test
. Activate the contrast plugin
. Scroll down to the error for the div with a gradient background
. Activate the "Preview" checkbox, and see a gray rectangle appear behind the text
. Deactivate the "Preview" checkbox, and **see the rectangle disappear**