### PR TITLE
Show Error Code - #18

### DIFF
--- a/less/base.less
+++ b/less/base.less
@@ -45,7 +45,7 @@
     }
 
     pre {
-        padding: 10px;
+        padding: 5px 10px;
         margin: 0 0 10px;
         overflow-x: scroll;
     }

--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -12,8 +12,8 @@
         </div>
     </a>
     <div class="tota11y-info-error-description tota11y-collapsed">
-        <div class="tota11y-info-error-description-code"> 
-            Surrounding code:
+        <div class="tota11y-info-error-description-code-container"> 
+            Element's Code:
             <code></code> 
         </div>
     </div>

--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -13,7 +13,7 @@
     </a>
     <div class="tota11y-info-error-description tota11y-collapsed">
         <div class="tota11y-info-error-description-code-container"> 
-            Element's Code:
+            <em> Relevant code: </em>
             <code></code> 
         </div>
     </div>

--- a/plugins/shared/info-panel/error.handlebars
+++ b/plugins/shared/info-panel/error.handlebars
@@ -11,5 +11,10 @@
             {{{title}}}
         </div>
     </a>
-    <div class="tota11y-info-error-description tota11y-collapsed"></div>
+    <div class="tota11y-info-error-description tota11y-collapsed">
+        <div class="tota11y-info-error-description-code"> 
+            Surrounding code:
+            <code></code> 
+        </div>
+    </div>
 </li>

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -280,13 +280,18 @@ class InfoPanel {
                 annotate.toggleHighlight(error.$el, $trigger);
                 annotate.toggleHighlight(error.$el, $scroll);
 
-                // Add surrounding code from error.$el to the information panel
+                // Add code from error.$el to the information panel
                 // The code will appear in the error description inside
-                // tota11y-info-error-description-code
+                // tota11y-info-error-description-code-container
 
-                //Grab parent wrapper's html and trim the returned string
-                let surroundingCode = $(error.$el).parent().html().trim();
-                $error.find(".tota11y-info-error-description-code code").text(surroundingCode);
+                let errorHTML = $(error.$el)[0].outerHTML;
+
+                // Trim the code block if it is over 300 characters
+                if (errorHTML.length > 300) {
+                    errorHTML = errorHTML.substring(0, 300) + "...";
+                }
+
+                $error.find(".tota11y-info-error-description-code-container code").text(errorHTML);
             });
 
             $errorsTab = $activeTab = this._addTab("Errors", $errors);

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -218,7 +218,7 @@ class InfoPanel {
                 // so that functionality can be inserted.
                 $error
                     .find(".tota11y-info-error-description")
-                    .append(error.$description);
+                    .prepend(error.$description);
 
                 $errors.append($error);
 
@@ -279,6 +279,14 @@ class InfoPanel {
                 // highlight when scrolling to the element with the button.
                 annotate.toggleHighlight(error.$el, $trigger);
                 annotate.toggleHighlight(error.$el, $scroll);
+
+                // Add surrounding code from error.$el to the information panel
+                // The code will appear in the error description inside
+                // tota11y-info-error-description-code
+
+                //Grab parent wrapper's html and trim the returned string
+                let surroundingCode = $(error.$el).parent().html().trim();
+                $error.find(".tota11y-info-error-description-code code").text(surroundingCode);
             });
 
             $errorsTab = $activeTab = this._addTab("Errors", $errors);

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -183,17 +183,14 @@
             padding: 10px 0 0;
             user-select: text;
 
-            &-code {
+            &-code-container {
                 margin-top: @panelPadding;
 
                 code {
-                    display: -webkit-box;
+                    display: block;
                     margin-top: 10px; 
-                    overflow: hidden;
                     padding: 5px @panelPadding;
                     word-wrap: break-word;
-                    -webkit-line-clamp: 15;
-                    -webkit-box-orient: vertical;
                 }
             }
             &.tota11y-collapsed {

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -183,6 +183,19 @@
             padding: 10px 0 0;
             user-select: text;
 
+            &-code {
+                margin-top: 10px;
+
+                code {
+                    display: -webkit-box;
+                    margin-top: 10px; 
+                    overflow: hidden; 
+                    padding: 10px;
+                    word-wrap: break-word;
+                    -webkit-line-clamp: 15;
+                    -webkit-box-orient: vertical;
+                }
+            }
             &.tota11y-collapsed {
                 display: none
             }

--- a/plugins/shared/info-panel/style.less
+++ b/plugins/shared/info-panel/style.less
@@ -184,13 +184,13 @@
             user-select: text;
 
             &-code {
-                margin-top: 10px;
+                margin-top: @panelPadding;
 
                 code {
                     display: -webkit-box;
                     margin-top: 10px; 
-                    overflow: hidden; 
-                    padding: 10px;
+                    overflow: hidden;
+                    padding: 5px @panelPadding;
                     word-wrap: break-word;
                     -webkit-line-clamp: 15;
                     -webkit-box-orient: vertical;


### PR DESCRIPTION
This PR will add the "surrounding code" to every error that is displayed inside of the information pane. This surrounding code consists of the element causing the error and its immediate parent. 

This PR also changes the style of the info pane code blocks to better handle ellipses if needed. 

Related issue: https://github.com/Khan/tota11y/issues/18

![screen shot on 2015-09-15 at 13-59-39](https://cloud.githubusercontent.com/assets/826190/9885235/21defe34-5bb2-11e5-97f8-d4957e3fad88.png)