### PR TITLE
Use Integer Value 1 instead of $.window.Node.ELEMENT_NODE #75

### DIFF
--- a/plugins/shared/audit.js
+++ b/plugins/shared/audit.js
@@ -43,7 +43,9 @@ function patchCollectMatchingElements() {
      */
     $.axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
                                                        opt_shadowRoot) {
-        if (node.nodeType == $.window.Node.ELEMENT_NODE)
+        // Only create element if the node is an element
+        // node (e.g Node.ELEMENT_NODE === 1)
+        if (node.nodeType === 1)
             var element = /** @type {Element} */ (node);
 
         if (element && matcher.call(null, element))

--- a/test/mock-dom/jquery-extensions.js
+++ b/test/mock-dom/jquery-extensions.js
@@ -25,6 +25,3 @@ $.fn.expandedText = function() {
 
 // Bind the global `axs` object from Accessibility Developer Tools to jQuery
 $.axs = window.axs;
-
-// Bind the global `window` object as well as a catch-all
-$.window = window;


### PR DESCRIPTION
Since $.window.Node no longer exists, we can simply check for the integer value 1 when comparing to the node.nodeType. This fixes #75 and all plugins seem to be working as intended. 

Thanks @jdan for helping out with the solution! 