### PR TITLE
Removed gross $.axs, dom.$, etc. hacks in favor of modifying global.__proto__

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "rules": {
         "comma-dangle": 0,
         "no-underscore-dangle": 0,
+        "no-proto": 0,
         "quotes": [2, "double"],
         "space-after-keywords": [2, "always"],
         "space-infix-ops": 0,
@@ -18,6 +19,7 @@
         "jsx": true,
     },
     "globals": {
-        "axs": true
+        "axs": true,
+        "$": true,
     }
 }

--- a/index.js
+++ b/index.js
@@ -112,9 +112,6 @@ class Toolbar {
 }
 
 $(function() {
-    // Attach the global `axs` object from Accessibility Developer Tools to $
-    $.axs = axs;
-
     var bar = new Toolbar();
 
     // TODO: Make this customizable

--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -25,7 +25,7 @@ class A11yTextWand extends Plugin {
         $(document).on("mousemove.wand", function(e) {
             let element = document.elementFromPoint(e.clientX, e.clientY);
 
-            let textAlternative = $.axs.properties.findTextAlternatives(
+            let textAlternative = axs.properties.findTextAlternatives(
                 element, {});
 
             $(".tota11y-outlined").removeClass("tota11y-outlined");

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -75,7 +75,7 @@ class LinkTextPlugin extends Plugin {
             // TODO: Read from `alts` to determine where the text is coming
             // from (for tailored error messages)
             let alts = {};
-            let extractedText = $.axs.properties.findTextAlternatives(
+            let extractedText = axs.properties.findTextAlternatives(
                 el, alts);
 
             if (!this.isDescriptiveText(extractedText)) {

--- a/plugins/shared/audit.js
+++ b/plugins/shared/audit.js
@@ -2,8 +2,6 @@
  * Abstractions for how we use Accessibility Developer Tools
  */
 
-let $ = require("jquery");
-
 function allRuleNames() {
     return axs.AuditRules.getRules().map(rule => rule.name);
 }

--- a/plugins/shared/audit.js
+++ b/plugins/shared/audit.js
@@ -5,13 +5,13 @@
 let $ = require("jquery");
 
 function allRuleNames() {
-    return $.axs.AuditRules.getRules().map(rule => rule.name);
+    return axs.AuditRules.getRules().map(rule => rule.name);
 }
 
 // Creates an audit configuration that whitelists a single rule and limits the
 // amount of tests to run
 function createWhitelist(ruleName) {
-    var config = new $.axs.AuditConfiguration();
+    var config = new axs.AuditConfiguration();
     config.showUnsupportedRulesWarning = false;
 
     // Ignore elements that are part of the toolbar
@@ -41,7 +41,7 @@ function patchCollectMatchingElements() {
      * @param {Array.<Element>} collection
      * @param {ShadowRoot=} opt_shadowRoot The nearest ShadowRoot ancestor, if any.
      */
-    $.axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
+    axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
                                                        opt_shadowRoot) {
         if (node.nodeType === Node.ELEMENT_NODE)
             var element = /** @type {Element} */ (node);
@@ -58,7 +58,7 @@ function patchCollectMatchingElements() {
             // code, be sure to run the tests in the browser before committing.
             var shadowRoot = element.shadowRoot || element.webkitShadowRoot;
             if (shadowRoot) {
-                $.axs.AuditRule.collectMatchingElements(shadowRoot,
+                axs.AuditRule.collectMatchingElements(shadowRoot,
                                                         matcher,
                                                         collection,
                                                         shadowRoot);
@@ -73,7 +73,7 @@ function patchCollectMatchingElements() {
             var content = /** @type {HTMLContentElement} */ (element);
             var distributedNodes = content.getDistributedNodes();
             for (var i = 0; i < distributedNodes.length; i++) {
-                $.axs.AuditRule.collectMatchingElements(distributedNodes[i],
+                axs.AuditRule.collectMatchingElements(distributedNodes[i],
                                                         matcher,
                                                         collection,
                                                         opt_shadowRoot);
@@ -90,7 +90,7 @@ function patchCollectMatchingElements() {
             } else {
                 var distributedNodes = shadow.getDistributedNodes();
                 for (var i = 0; i < distributedNodes.length; i++) {
-                    $.axs.AuditRule.collectMatchingElements(distributedNodes[i],
+                    axs.AuditRule.collectMatchingElements(distributedNodes[i],
                                                             matcher,
                                                             collection,
                                                             opt_shadowRoot);
@@ -102,7 +102,7 @@ function patchCollectMatchingElements() {
         // a <shadow> element recurse normally.
         var child = node.firstChild;
         while (child != null) {
-            $.axs.AuditRule.collectMatchingElements(child,
+            axs.AuditRule.collectMatchingElements(child,
                                                     matcher,
                                                     collection,
                                                     opt_shadowRoot);
@@ -119,7 +119,7 @@ function audit(ruleName) {
 
     patchCollectMatchingElements();
 
-    return $.axs.Audit.run(whitelist)
+    return axs.Audit.run(whitelist)
         .filter(result => result.rule.name === ruleName)[0];
 }
 

--- a/plugins/shared/audit.js
+++ b/plugins/shared/audit.js
@@ -43,8 +43,7 @@ function patchCollectMatchingElements() {
      */
     $.axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
                                                        opt_shadowRoot) {
-        // Only assign if node is an element (i.e. <p> vs <!-- comment -->)
-        if (node.nodeType === 1)
+        if (node.nodeType === Node.ELEMENT_NODE)
             var element = /** @type {Element} */ (node);
 
         if (element && matcher.call(null, element))

--- a/test/alt-text-test.js
+++ b/test/alt-text-test.js
@@ -6,16 +6,10 @@ let assert = require("assert");
 let mockDom = require("./mock-dom");
 
 describe("Alt text plugin", function() {
-    let dom = null;
     let plugin = null;
 
     before(function(done) {
-        mockDom.createDom(function(domObj) {
-            // Assign `dom` to the object returned by createDom, which allows
-            // us to set the HTML of the virtual environment, query it, and
-            // close the window.
-            dom = domObj;
-
+        mockDom.createDom(function() {
             let LinkTextPlugin = require("../plugins/alt-text");
             plugin = new LinkTextPlugin();
 
@@ -24,27 +18,27 @@ describe("Alt text plugin", function() {
     });
 
     it("should label images without alt text", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <img id="bad-img" src="test.jpg" />
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#bad-img").hasErrorLabel());
+        assert($("#bad-img").hasErrorLabel());
     });
 
     it("should not label images with alt text", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <img id="good-img" src="test.jpg" alt="This is a description" />
-        `);
+        `;
 
         plugin.run();
 
-        assert(!dom.$("#good-img").hasLabel());
+        assert(!$("#good-img").hasLabel());
     });
 
     it("should not label images with aria-labels", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <div id="label">Hello</div>
             <img id="img-with-aria-labelledby"
                  aria-labelledby="label"
@@ -53,44 +47,40 @@ describe("Alt text plugin", function() {
             <img id="img-with-aria-label"
                  aria-label="This is a label"
                  src="test2.jpg" />
-        `);
+        `;
 
-        assert(!dom.$("img-with-aria-labelledby").hasLabel());
-        assert(!dom.$("img-with-aria-label").hasLabel());
+        assert(!$("img-with-aria-labelledby").hasLabel());
+        assert(!$("img-with-aria-label").hasLabel());
     });
 
     it("should not label hidden images without alt text", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <div style="display:none">
                 <img id="hidden-bad-img" src="test.jpg" />
             </div>
             <img aria-hidden="true" id="aria-hidden-bad-img" />
-        `);
+        `;
 
         plugin.run();
 
-        assert(!dom.$("#hidden-bad-img").hasLabel());
-        assert(!dom.$("#aria-hidden-bad-img").hasLabel());
+        assert(!$("#hidden-bad-img").hasLabel());
+        assert(!$("#aria-hidden-bad-img").hasLabel());
     });
 
     it("should label presentational images with warnings", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <img id="empty-alt" src="test.jpg" alt="" />
             <img id="presentational" role="presentation" src="test2.jpg" />
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#empty-alt").hasErrorLabel());
-        assert(dom.$("#empty-alt").hasClass("tota11y-label-warning"));
-        assert(/decorative/.test(dom.$("#empty-alt").expandedText()));
+        assert($("#empty-alt").hasErrorLabel());
+        assert($("#empty-alt").hasClass("tota11y-label-warning"));
+        assert(/decorative/.test($("#empty-alt").expandedText()));
 
-        assert(dom.$("#presentational").hasErrorLabel());
-        assert(dom.$("#presentational").hasClass("tota11y-label-warning"));
-        assert(/decorative/.test(dom.$("#presentational").expandedText()));
-    });
-
-    after(function() {
-        dom.destroy();
+        assert($("#presentational").hasErrorLabel());
+        assert($("#presentational").hasClass("tota11y-label-warning"));
+        assert(/decorative/.test($("#presentational").expandedText()));
     });
 });

--- a/test/landmarks-test.js
+++ b/test/landmarks-test.js
@@ -6,16 +6,10 @@ let assert = require("assert");
 let mockDom = require("./mock-dom");
 
 describe("Landmarks plugin", function() {
-    let dom = null;
     let plugin = null;
 
     before(function(done) {
-        mockDom.createDom(function(domObj) {
-            // Assign `dom` to the object returned by createDom, which allows
-            // us to set the HTML of the virtual environment, query it, and
-            // close the window.
-            dom = domObj;
-
+        mockDom.createDom(function() {
             let LandmarksPlugin = require("../plugins/landmarks");
             plugin = new LandmarksPlugin();
 
@@ -24,31 +18,27 @@ describe("Landmarks plugin", function() {
     });
 
     it("should label tags with a role", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <div id="main-div" role="main">
                 Hello, world!
             </div>
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#main-div").hasLabel());
-        assert(dom.$("#main-div").labelText() === "main");
+        assert($("#main-div").hasLabel());
+        assert($("#main-div").labelText() === "main");
     });
 
     it("should not label tags without a role", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <div id="main-div">
                 Hello, world!
             </div>
-        `);
+        `;
 
         plugin.run();
 
-        assert(!dom.$("#main-div").hasLabel());
-    });
-
-    after(function() {
-        dom.destroy();
+        assert(!$("#main-div").hasLabel());
     });
 });

--- a/test/link-text-test.js
+++ b/test/link-text-test.js
@@ -6,16 +6,10 @@ let assert = require("assert");
 let mockDom = require("./mock-dom");
 
 describe("Link text plugin", function() {
-    let dom = null;
     let plugin = null;
 
     before(function(done) {
-        mockDom.createDom(function(domObj) {
-            // Assign `dom` to the object returned by createDom, which allows
-            // us to set the HTML of the virtual environment, query it, and
-            // close the window.
-            dom = domObj;
-
+        mockDom.createDom(function() {
             let LinkTextPlugin = require("../plugins/link-text");
             plugin = new LinkTextPlugin();
 
@@ -24,67 +18,67 @@ describe("Link text plugin", function() {
     });
 
     it("should not label descriptive links", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#" id="good-link">
                 This is a descriptive link
             </a>
-        `);
+        `;
 
         plugin.run();
 
-        assert(!dom.$("#good-link").hasLabel());
+        assert(!$("#good-link").hasLabel());
     });
 
     it("should label unclear links", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#" id="bad-link">Click here</a> to learn more about
             dinosaurs. You can also <a id="better-link" href="#">
             check out my blog</a>.
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#bad-link").hasLabel());
-        assert(!dom.$("#better-link").hasLabel());
+        assert($("#bad-link").hasLabel());
+        assert(!$("#better-link").hasLabel());
     });
 
     it("should consider alt text as link text", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#" id="logo-link">
                 <img src="/images/logo.png" alt="Our logo" />
             </a>
-        `);
+        `;
 
         plugin.run();
 
         // TODO: Test the extended error messages for the presence of "alt"
-        assert(!dom.$("#logo-link").hasLabel());
+        assert(!$("#logo-link").hasLabel());
     });
 
     it("should fail on image links with unclear alt text", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#" id="bad-image-link">
                 <img src="/images/banner.png" alt="Click here" />
             </a>
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#bad-image-link").hasLabel());
+        assert($("#bad-image-link").hasLabel());
     });
 
     it("should fail on empty links", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#" id="empty-link"></a>
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#empty-link").hasLabel());
+        assert($("#empty-link").hasLabel());
     });
 
     it("should pass on empty links with aria-labels", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#"
                aria-label="this is a detailed description"
                id="empty-link-with-label">
@@ -95,16 +89,16 @@ describe("Link text plugin", function() {
                id="empty-link-with-labelledby">
             </a>
             <span id="link-description">This is a detailed description</span>
-        `);
+        `;
 
         plugin.run();
 
-        assert(!dom.$("#empty-link-with-label").hasLabel());
-        assert(!dom.$("#empty-link-with-labelledby").hasLabel());
+        assert(!$("#empty-link-with-label").hasLabel());
+        assert(!$("#empty-link-with-labelledby").hasLabel());
     });
 
     it("should fail on links with unclear aria-labels", function() {
-        dom.setHTML(`
+        document.body.innerHTML = `
             <a href="#"
                aria-label="click here"
                id="empty-link-with-unclear-label">
@@ -117,15 +111,11 @@ describe("Link text plugin", function() {
                 This is a longer description that will not be picked up
             </a>
             <span id="link-description">Click here</span>
-        `);
+        `;
 
         plugin.run();
 
-        assert(dom.$("#empty-link-with-unclear-label").hasLabel());
-        assert(dom.$("#empty-link-with-unclear-labelledby").hasLabel());
-    });
-
-    after(function() {
-        dom.destroy();
+        assert($("#empty-link-with-unclear-label").hasLabel());
+        assert($("#empty-link-with-unclear-labelledby").hasLabel());
     });
 });

--- a/test/mock-dom/index.js
+++ b/test/mock-dom/index.js
@@ -35,6 +35,17 @@ exports.createDom = function(callback) {
         html: "",
         src: [axsSrc, jquerySrc, jqueryExtSrc],
         done: function(errors, window) {
+            // Expose some fields from `window` onto the global namespace
+            //
+            // TODO: Currently we add fields here (see "Node") as we need
+            // them, but this may prove tricky to maintain.
+            global.__proto__ = {
+                document: window.document,
+                $: window.jQuery,
+                axs: window.axs,
+                Node: window.Node,
+            };
+
             // Overwrite the default module loader.
             //
             // Here we intercept `require()` calls to stub out the annotations
@@ -61,17 +72,7 @@ exports.createDom = function(callback) {
                 }
             };
 
-            callback({
-                setHTML(html) {
-                    window.document.body.innerHTML = html;
-                },
-
-                destroy() {
-                    window.close();
-                },
-
-                $: window.jQuery,
-            });
+            callback();
         }
     });
 };

--- a/test/mock-dom/index.js
+++ b/test/mock-dom/index.js
@@ -33,14 +33,12 @@ exports.createDom = function(callback) {
         done: function(errors, window) {
             // Expose some fields from `window` onto the global namespace
             //
-            // TODO: Currently we add fields here (see "Node") as we need
-            // them, but this may prove tricky to maintain.
-            global.__proto__ = {
-                document: window.document,
-                $: window.jQuery,
-                axs: window.axs,
-                Node: window.Node,
-            };
+            // TODO: Currently we add fields here as we need them, but this
+            // may prove tricky to maintain.
+            global.document = window.document;
+            global.$ = window.jQuery;
+            global.axs = window.axs;
+            global.Node = window.Node;
 
             // Overwrite the default module loader.
             //

--- a/test/mock-dom/index.js
+++ b/test/mock-dom/index.js
@@ -2,17 +2,13 @@
  * A utility that allows us to mock the DOM and run plugins exactly as they
  * are written.
  *
- * This utility also universally changes the behavior of "require", allowing
- * us to stub out annotations, less/handlebars modules, and even replace
- * requests for jQuery with our own copy.
+ * This module changes the behavior of "require," allowing us to stub out
+ * imports of jQuery and the annotations module.
  *
- * Exported is a `createDom` function, which sets up a jsdom environment and
- * sends to the callback an object containing the following:
- *
- *   - setHTML: which allows tests to change the HTML content of the page
- *   - $: which allows tests to access the jQuery instance running on the page
- *   - destroy: which allows tests to destroy the page. This is typically run
- *              in the magic `after` function of a mocha test group.
+ * Additionally, the module exposes a number of variables from the jsdom
+ * instance to the global namespace. Allowing us to code as if we're in
+ * a browser environment (i.e. using "document") while skipping the webpack
+ * bundling step.
  */
 
 let fs = require("fs");

--- a/test/mock-dom/jquery-extensions.js
+++ b/test/mock-dom/jquery-extensions.js
@@ -20,6 +20,3 @@ $.fn.labelText = function() {
 $.fn.expandedText = function() {
     return $(this).data("expanded-text");
 };
-
-// Bind the global `axs` object from Accessibility Developer Tools to jQuery
-$.axs = window.axs;

--- a/test/mock-dom/jquery-extensions.js
+++ b/test/mock-dom/jquery-extensions.js
@@ -5,8 +5,6 @@
  * This file will be loaded into test documents by the mock-dom utility.
  */
 
-var $ = window.jQuery;
-
 $.fn.hasLabel = function() {
     return !!$(this).data("has-label");
 };


### PR DESCRIPTION
@MichelleTodd && @rileyjshaw,

This changeset contains cleanup to get rid of some hacks, in favor of way cooler hacks.

Specifically, we used to communicate to the jsdom environment solely through `$`, leading to code like `$.axs` and `$.window` scattered around the codebase. These hacks were in place so that our unit tests would work, but that has proven to be a weak compromise.

Now, the `mock-dom` module changes the global namespace (via `global.__proto__`) to allow us to simply use `document` and `$` in our unit tests, even though it looks like those variables don't exist. There's some precedence for this already, as `mock-dom` changes the behavior of `require` in unit-test land.

The callback to `mock-dom` is also much simpler now, as we'll have direct access to `document.body.innerHTML` and do not need to run `document.close()`.