### PR TITLE
Use .focus() instead of .scrollTop() to focus elements

### DIFF
--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -295,8 +295,12 @@ class InfoPanel {
                     e.preventDefault();
                     e.stopPropagation();
 
-                    // TODO: This attempts to scroll to fixed elements
-                    $(document).scrollTop(error.$el.offset().top - 80);
+                    // Add tabIndex if element is not currently focusable
+                    if(!error.$el.is(axs.utils.FOCUSABLE_ELEMENTS_SELECTOR)){
+                        error.$el.attr("tabindex", -1);
+                    }
+
+                    error.$el.focus();
                 });
 
                 // Expand the first violation

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -296,7 +296,7 @@ class InfoPanel {
                     e.stopPropagation();
 
                     // Add tabIndex if element is not currently focusable
-                    if(!error.$el.is(axs.utils.FOCUSABLE_ELEMENTS_SELECTOR)){
+                    if (!error.$el.is(axs.utils.FOCUSABLE_ELEMENTS_SELECTOR)){
                         error.$el.attr("tabindex", -1);
                     }
 


### PR DESCRIPTION
In this #17: The scrollTop has some issues when the element is position fixed or in other tricky situations. To fix this, we can use focus to get both the scroll and highlight of the element. 
![screen capture on 2015-10-05 at 10-39-10](https://cloud.githubusercontent.com/assets/826190/10283403/78387602-6b4d-11e5-85cd-85ad062d05f1.gif)

The if statement is adding a tabindex of -1 to anything that is not focusable :) 