### PR TITLE
Remove interactions between plugins and the info panel

### DIFF
--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -3,6 +3,7 @@
  */
 
 let $ = require("jquery");
+let annotate = require("../shared/annotate")("a11y-wand");
 let Plugin = require("../base");
 
 require("./style.less");
@@ -17,11 +18,6 @@ class A11yTextWand extends Plugin {
     }
 
     run() {
-        // HACK(jordan): We provide a fake summary to force the info panel to
-        //     render.
-        this.summary(" ");
-        this.panel.render();
-
         $(document).on("mousemove.wand", function(e) {
             let element = document.elementFromPoint(e.clientX, e.clientY);
 
@@ -32,13 +28,13 @@ class A11yTextWand extends Plugin {
             $(element).addClass("tota11y-outlined");
 
             if (!textAlternative) {
-                $(".tota11y-info-section.active").html(
+                annotate.summary(
                     <i className="tota11y-nothingness">
                         No text visible to a screen reader
                     </i>
                 );
             } else {
-                $(".tota11y-info-section.active").text(textAlternative);
+                annotate.summary(textAlternative);
             }
         });
     }
@@ -46,6 +42,7 @@ class A11yTextWand extends Plugin {
     cleanup() {
         $(".tota11y-outlined").removeClass("tota11y-outlined");
         $(document).off("mousemove.wand");
+        annotate.removeAll();
     }
 }
 

--- a/plugins/alt-text/index.js
+++ b/plugins/alt-text/index.js
@@ -46,10 +46,7 @@ class AltTextPlugin extends Plugin {
             </div>
         );
 
-        // Place an error label on the element and register it as an
-        // error in the info panel
-        let entry = this.error(title, $error, $el);
-        annotate.errorLabel($el, "", title, entry);
+        annotate.error($el, "", title, $error);
     }
 
     run() {
@@ -66,7 +63,7 @@ class AltTextPlugin extends Plugin {
             // "Error" labels have a warning icon and expanded text on hover,
             // but we add a special `warning` class to color it differently.
             annotate
-                .errorLabel($(el), "", "This image is decorative")
+                .error($(el), "", "This image is decorative")
                 .addClass("tota11y-label-warning");
         });
     }

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -9,13 +9,10 @@
  *     cleanup: code to run when the plugin is deactivated from the toolbar
  */
 
-let InfoPanel = require("./shared/info-panel");
-
 require("./style.less");
 
 class Plugin {
     constructor() {
-        this.panel = new InfoPanel(this);
         this.$checkbox = null;
     }
 
@@ -25,26 +22,6 @@ class Plugin {
 
     getDescription() {
         return "";
-    }
-
-    /**
-     * Methods that communicate directly with the info panel
-     * TODO: Consider names like `setSummary` and `addError`
-     */
-
-    // Populates the info panel's "Summary" tab
-    summary($html) {
-        return this.panel.setSummary($html);
-    }
-
-    // Populates the info panel's "About" tab
-    about($html) {
-        return this.panel.setAbout($html);
-    }
-
-    // Adds an entry to the info panel's "Errors" tab
-    error(title, $description, $el) {
-        return this.panel.addError(title, $description, $el);
     }
 
     /**
@@ -90,7 +67,6 @@ class Plugin {
      */
     activate() {
         this.run();
-        this.panel.render();
     }
 
     /**
@@ -98,8 +74,6 @@ class Plugin {
      */
     deactivate() {
         this.cleanup();
-        this.panel.destroy();
-
         this.$checkbox.prop("checked", false);
     }
 }

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -50,9 +50,7 @@ class ContrastPlugin extends Plugin {
         let originalFgColor = style.color;
         let originalBgColor = style.backgroundColor;
 
-        console.log('added')
         $description.find(".preview-contrast-fix").click((e) => {
-            console.log('click!')
             if ($(e.target).prop("checked")) {
                 // Set suggested colors
                 $(el).css("color", suggestedColors.fg);

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -50,7 +50,9 @@ class ContrastPlugin extends Plugin {
         let originalFgColor = style.color;
         let originalBgColor = style.backgroundColor;
 
+        console.log('added')
         $description.find(".preview-contrast-fix").click((e) => {
+            console.log('click!')
             if ($(e.target).prop("checked")) {
                 // Set suggested colors
                 $(el).css("color", suggestedColors.fg);
@@ -62,10 +64,11 @@ class ContrastPlugin extends Plugin {
             }
         });
 
-        return this.error(
+        annotate.error(
+            $(el),
+            contrastRatio,
             titleTemplate(templateData),
-            $description,
-            $(el));
+            $description);
     }
 
     run() {
@@ -121,38 +124,20 @@ class ContrastPlugin extends Plugin {
                     combinations[key] = true;
                 }
             } else {
-                if (!combinations[key]) {
-                    // We do not show duplicates in the errors panel, however,
-                    // to keep the output from being overwhelming
-                    let error = this.addError({
-                        style,
-                        fgColor,
-                        bgColor,
-                        contrastRatio,
-                        requiredRatio,
-                    }, el);
-
-                    // Save original color so it can be restored on cleanup.
-                    this.preservedColors.push({
-                        $el: $(el),
-                        fg: style.color,
-                        bg: style.backgroundColor,
-                    });
-
-                    combinations[key] = error;
-                }
-
-                // We display errors multiple times for emphasis. Each error
-                // will point back to the entry in the info panel for that
-                // particular color combination.
-                //
-                // TODO: The error entry in the info panel will only highlight
-                // the first element with that color combination
-                annotate.errorLabel(
-                    $(el),
+                this.addError({
+                    style,
+                    fgColor,
+                    bgColor,
                     contrastRatio,
-                    "This contrast is insufficient at this size.",
-                    combinations[key]);
+                    requiredRatio,
+                }, el);
+
+                // Save original color so it can be restored on cleanup.
+                this.preservedColors.push({
+                    $el: $(el),
+                    fg: style.color,
+                    bg: style.backgroundColor,
+                });
             }
         });
     }

--- a/plugins/headings/index.js
+++ b/plugins/headings/index.js
@@ -116,16 +116,12 @@ class HeadingsPlugin extends Plugin {
             annotate.toggleHighlight($el, $item);
 
             if (error) {
-                // Register an error to the info panel
-                let infoPanelError = this.error(
-                    error.title, $(error.description), $el);
-
                 // Place an error label on the heading tag
-                annotate.errorLabel(
+                annotate.error(
                     $el,
                     $el.prop("tagName").toLowerCase(),
                     error.title,
-                    infoPanelError);
+                    $(error.description));
 
                 // Mark the summary item as red
                 // Pretty hacky, since we're borrowing label styles for this
@@ -159,7 +155,7 @@ class HeadingsPlugin extends Plugin {
                 </div>
             );
 
-            this.summary($outline);
+            annotate.summary($outline);
         }
     }
 

--- a/plugins/labels/index.js
+++ b/plugins/labels/index.js
@@ -33,11 +33,7 @@ class LabelsPlugin extends Plugin {
             elements.forEach((element) => {
                 let $el = $(element);
                 let title = "Input is missing a label";
-
-                // Place an error label on the element and register it as an
-                // error in the info panel
-                let entry = this.error(title, $(this.errorMessage($el)), $el);
-                annotate.errorLabel($el, "", title, entry);
+                annotate.error($el, "", title, $(this.errorMessage($el)));
             });
         }
     }

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -49,9 +49,8 @@ class LinkTextPlugin extends Plugin {
     }
 
     reportError($el, $description, content) {
-        let entry = this.error("Link text is unclear", $description, $el);
-        annotate.errorLabel($el, "",
-            `Link text "${content}" is unclear`, entry);
+        annotate.error($el, "",
+            `Link text "${content}" is unclear`, $description);
     }
 
     /**

--- a/plugins/shared/annotate/error-label.handlebars
+++ b/plugins/shared/annotate/error-label.handlebars
@@ -13,7 +13,7 @@
 
 <span class="tota11y-label-content">
     <div class="tota11y-label-text">{{{text}}}</div>
-    {{#if hasErrorEntry}}
+    {{#if hasError}}
         <div class="tota11y-label-help">
             (<a class="tota11y-label-link" href="#">?</a>)
         </div>

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -15,7 +15,6 @@
  */
 
 let $ = require("jquery");
-let annotate = require("../annotate")("info-panel");
 
 let errorTemplate = require("./error.handlebars");
 require("./style.less");
@@ -25,8 +24,8 @@ const COLLAPSED_CLASS_NAME = "tota11y-collapsed";
 const HIDDEN_CLASS_NAME = "tota11y-info-hidden";
 
 class InfoPanel {
-    constructor(plugin) {
-        this.plugin = plugin;
+    constructor(annotate) {
+        this.annotate = annotate;
 
         this.about = null;
         this.summary = null;
@@ -40,6 +39,7 @@ class InfoPanel {
      */
     setAbout(about) {
         this.about = about;
+        this.render();
     }
 
     /**
@@ -47,6 +47,7 @@ class InfoPanel {
      */
     setSummary(summary) {
         this.summary = summary;
+        this.render();
     }
 
     /**
@@ -56,6 +57,7 @@ class InfoPanel {
     addError(title, $description, $el) {
         let error = {title, $description, $el};
         this.errors.push(error);
+        this.render();
         return error;
     }
 
@@ -116,7 +118,8 @@ class InfoPanel {
             this.$el.addClass(HIDDEN_CLASS_NAME);
 
             // (a11y) Bring the focus back to the plugin's checkbox
-            this.plugin.$checkbox.focus();
+            // FIX
+            //this.plugin.$checkbox.focus();
         });
 
         // Append the info panel to the body. In reality we'll likely want
@@ -190,7 +193,8 @@ class InfoPanel {
         this.$el = (
             <div className="tota11y tota11y-info" tabindex="-1">
                 <header className="tota11y-info-title">
-                    {this.plugin.getTitle()}
+                    {/* TODO: plugin title */}
+                    {"Plugin"}
                     <span className="tota11y-info-controls">
                         <label className="tota11y-info-annotation-toggle">
                             Annotate:
@@ -228,9 +232,9 @@ class InfoPanel {
         // Wire annotation toggling
         this.$el.find(".toggle-annotation").click((e) => {
             if ($(e.target).prop("checked")) {
-                annotate.show();
+                this.annotate.show();
             } else {
-                annotate.hide();
+                this.annotate.hide();
             }
         });
 
@@ -308,8 +312,8 @@ class InfoPanel {
                 // Highlight the violating element on hover/focus. We do it
                 // for both $trigger and $scroll to allow users to see the
                 // highlight when scrolling to the element with the button.
-                annotate.toggleHighlight(error.$el, $trigger);
-                annotate.toggleHighlight(error.$el, $scroll);
+                this.annotate.toggleHighlight(error.$el, $trigger);
+                this.annotate.toggleHighlight(error.$el, $scroll);
 
                 // Add code from error.$el to the information panel
                 let errorHTML = error.$el[0].outerHTML;
@@ -363,9 +367,6 @@ class InfoPanel {
             this.$el.remove();
             this.$el = null;
         }
-
-        // Remove the annotations
-        annotate.removeAll();
     }
 }
 

--- a/plugins/shared/info-panel/index.js
+++ b/plugins/shared/info-panel/index.js
@@ -117,9 +117,10 @@ class InfoPanel {
             e.stopPropagation();
             this.$el.addClass(HIDDEN_CLASS_NAME);
 
+            // TODO(jordan): We no longer have access to `this.plugin`, so
+            // is an a11y regression.
             // (a11y) Bring the focus back to the plugin's checkbox
-            // FIX
-            //this.plugin.$checkbox.focus();
+            // this.plugin.$checkbox.focus();
         });
 
         // Append the info panel to the body. In reality we'll likely want

--- a/test/mock-dom/annotate-stub.js
+++ b/test/mock-dom/annotate-stub.js
@@ -18,7 +18,7 @@ module.exports = () => {
             return $el;
         },
 
-        errorLabel($el, text, expanded) {
+        error($el, text, expanded) {
             $el.data({
                 "has-label": true,
                 "has-error-label": true,


### PR DESCRIPTION
Hi @MichelleTodd && @rileyjshaw,

Creating entries in the info panel is confusing. First the plugin needs to create an annotation, then it needs to create an entry in the info panel, referencing the annotation. The result is code like this scattered around tota11y's codebase:

```js
// Place an error label on the element and register it as an error in the info panel		
let entry = this.error(title, $error, $el);		
annotate.errorLabel($el, "", title, entry);
```

Now, all the interactions with the info panel are done through the annotations module, so plugins no longer touch the info panel except going through `annotate`. You'll notice that the source code to many modules is now much simpler.

There are two regressions included in this diff, namely:

* The plugin checkbox does not refocus when the info panel closes
* The contrast preview checkbox no longer works.

I will not be merging this diff into master, but in a separate "dev" branch which I will continue rewriting on.