### PR TITLE
Add explicit background-color to all elements

### DIFF
--- a/less/base.less
+++ b/less/base.less
@@ -9,6 +9,7 @@
     // A reset of all styles in tota11y elements
     &, & * {
         border: none;
+        background-color: inherit;
         box-sizing: border-box;
         color: @white;
         font-family: Arial;


### PR DESCRIPTION
This avoids cases where for example the `<header class="tota11y-info-title">`  could have its style overwritten by a `header { background-color: #fff }` css rule on the original page.