### PR TITLE
Fix swatches inheriting background-color

### DIFF
--- a/plugins/contrast/error-description.handlebars
+++ b/plugins/contrast/error-description.handlebars
@@ -19,12 +19,12 @@
         <span class="tota11y-swatches">
             <span
                 class="tota11y-swatch"
-                style="background-color: {{suggestedFgColorHex}}">
+                style="background-color: {{suggestedFgColorHex}} !important">
             </span>
             /
             <span
                 class="tota11y-swatch"
-                style="background-color: {{suggestedBgColorHex}}">
+                style="background-color: {{suggestedBgColorHex}} !important">
             </span>
         </span>
 

--- a/plugins/contrast/error-title.handlebars
+++ b/plugins/contrast/error-title.handlebars
@@ -1,7 +1,7 @@
 Insufficient contrast ratio ({{contrastRatio}} &lt; {{requiredRatio}})
 
 <span class="tota11y-swatches">
-    <span class="tota11y-swatch" style="background-color: {{fgColorHex}}"></span>
+    <span class="tota11y-swatch" style="background-color: {{fgColorHex}} !important"></span>
     /
-    <span class="tota11y-swatch" style="background-color: {{bgColorHex}}"></span>
+    <span class="tota11y-swatch" style="background-color: {{bgColorHex}} !important"></span>
 </span>


### PR DESCRIPTION
There is a rule `.tota11y, .tota11y * { background-color: inherit!important; }` that forces swatches to inherit the background color of their container, killing the purpose of color swatches. :)

This fixes it by forcing the swatch color.