### PR TITLE
add 0.1.6 changes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+* Ignore hidden links for LinkText plugin ([30dc0fd](https://github.com/Khan/tota11y/commit/30dc0fd))
+
 ## 0.1.5
 
 * Update travis.yml to use node v4 ([c3c47be](https://github.com/Khan/tota11y/commit/c3c47be))


### PR DESCRIPTION
 I looked at the commit history and figured out there’s only been one change since 0.1.5, so I took the liberty to add it as I was a bit confused when I wanted to download tota11y.