### PR TITLE
Change "main" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tota11y",
   "version": "0.1.6",
   "description": "An accessibility visualization toolkit",
+  "main": "build/tota11y.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Khan/tota11y.git"


### PR DESCRIPTION
Makes **_tota11y_** compatible with [Browserify](http://browserify.org/). Right now, when somebody wants to `require("tota11y")`, the import path [resolves](https://github.com/browserify/resolve) to `node_modules/tota11y/index.js` and results in the following error:

```
SyntaxError: Unexpected token (53:19) while parsing
/Users/…/node_modules/tota11y/index.js while parsing file:
/Users/…/node_modules/tota11y/index.js
```

I believe we should set the final bundle as the `main` file in `package.json`. It would make this project compatible with more bundlers which doesn't handle Less, JSX and Handlebars on their own.