### PR TITLE
fix(bookmarklet): Support 'file' protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
                     current page.
                 </p>
 
-                <a class="bookmarklet" href="javascript:(function(){var%20tota11y=document.createElement('SCRIPT');tota11y.type='text/javascript';tota11y.src='//khan.github.io/tota11y/tota11y/build/tota11y.min.js';document.getElementsByTagName('head')[0].appendChild(tota11y);})();" onclick="javascript:return false;">tota11y</a>
+                <a class="bookmarklet" href="javascript:(function(){var%20tota11y=document.createElement('SCRIPT');tota11y.type='text/javascript';tota11y.src='https://khan.github.io/tota11y/tota11y/build/tota11y.min.js';document.getElementsByTagName('head')[0].appendChild(tota11y);})();" onclick="javascript:return false;">tota11y</a>
             </div>
 
             <p>


### PR DESCRIPTION
The bookmarklet currently uses a protocol-independent URL to load the source, which means that pages viewed locally (`file:///`) will attempt to also load the library from the file tree, rather than the CDN. There is no compelling reason to load the asset on http vs https, even when viewing a plain-http page, and thus the protocol should be set to https explicitly.

This change fixes https://github.com/Khan/tota11y/issues/130

- [x] CLA Signed
- [x] Tested on `file:///` page
- [x] Tested on `https://` page
- [x] Tested on `http://` page