### PR TITLE
Adding prechecks for publish config and login

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,16 @@
     "webpack-cli": "^3.3.0",
     "webpack-dev-server": "^3.3.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build:prod": "NODE_ENV=production webpack --config webpack.config.babel.js",
     "build:dev": "webpack --config webpack.config.babel.js -d --devtool hidden",
     "lint": "eslint index.js plugins test utils",
     "test": "mocha --require test/babel-hook test/*.js",
     "start": "webpack-dev-server --config webpack.config.babel.js --hot --inline",
-    "publish": "git diff --stat --exit-code HEAD && npm test && npm run build:prod"
+    "publish": "node ./utils/pre-publish-checks.js && git diff --stat --exit-code HEAD && npm test && npm run build:prod"
   },
   "license": "MIT",
   "dependencies": {}

--- a/utils/pre-publish-checks.js
+++ b/utils/pre-publish-checks.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+/**
+ * Pre-publish checks to verify that our publish will go smoothly.
+ */
+const path = require("path");
+const {exec} = require("child_process");
+
+const checkPublishConfig = (publishConfig) => {
+    if (!publishConfig || publishConfig.access !== "public") {
+        console.error("ERROR: Missing a \"publishConfig\": {\"access\": \"public\"} section.");
+        process.exit(1);
+    }
+};
+
+const checkNpmUser = (currentUser) => {
+    if (currentUser.trim() !== "khanacademy") {
+        console.error(
+            "ERROR: You are not logged in to NPM as \"khanacademy\". " +
+                "Run \"npm login\" and use the password from Keeper: " +
+                "NPM Open Source (https://npmjs.org)"
+        );
+        process.exit(1);
+    }
+};
+
+const pkgJson = require(path.join(__dirname, "..", "package.json"));
+const {publishConfig} = pkgJson;
+
+checkPublishConfig(publishConfig);
+exec("npm whoami", (err, currentUser) => {
+    checkNpmUser(currentUser);
+});


### PR DESCRIPTION

Copied from Wonder Blocks

Adds a check that there's a `prepublishConfig` and also checks that we're logged in as `khanacademy`