### PR TITLE
Update CHANGELOG for v0.2.0 and add release instructions


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,62 @@
+## 0.2.0
+
+- Get rid of build warnings and upgrade postcss ([493293d1](https://github.com/Khan/tota11y/commit/493293d1))
+- Added relative link to license.txt ([b3da3c63](https://github.com/Khan/tota11y/commit/b3da3c63))
+- bump accessibility-developer-tools (#111)
+- Use https instead of http for the url ([ce0d19ed](https://github.com/Khan/tota11y/commit/ce0d19ed))
+- menu-item is not a valid aria role (#118)
+- Change "main" field in package.json (#123)
+- Upgrade to Babel 6 (#135)
+- Upgrade to latest handlebars (#136)
+- Upgrade to latest jquery (#137)
+- Upgrade to latest eslint (#138)
+- Update to Webpack 4 and fix a lot of things (#145)
+- Add additional checks for publish (#146)
+- Adding prechecks for publish config and login (#147)
+- We're not using lerna so we need to do this BEFORE publish (#148)
+
 ## 0.1.6
 
-* Ignore hidden links for LinkText plugin ([30dc0fd](https://github.com/Khan/tota11y/commit/30dc0fd))
+- Ignore hidden links for LinkText plugin ([30dc0fd](https://github.com/Khan/tota11y/commit/30dc0fd))
 
 ## 0.1.5
 
-* Update travis.yml to use node v4 ([c3c47be](https://github.com/Khan/tota11y/commit/c3c47be))
-* Use semantic tags when listing plugins ([dc5425b](https://github.com/Khan/tota11y/commit/dc5425b))
-* Fix contrast plugin swatches not displaying correctly ([8a34c9b](https://github.com/Khan/tota11y/commit/8a34c9b))
+- Update travis.yml to use node v4 ([c3c47be](https://github.com/Khan/tota11y/commit/c3c47be))
+- Use semantic tags when listing plugins ([dc5425b](https://github.com/Khan/tota11y/commit/dc5425b))
+- Fix contrast plugin swatches not displaying correctly ([8a34c9b](https://github.com/Khan/tota11y/commit/8a34c9b))
 
 ## 0.1.4
 
-* Add explicit background to all elements ([54a3f5a](https://github.com/Khan/tota11y/commit/54a3f5a))
-* Skip the tota11y UI under the Landmarks plugin ([a3059e9](https://github.com/Khan/tota11y/commit/a3059e9))
-* Update jsdom and fix live-test script ([e5a418e](https://github.com/Khan/tota11y/commit/e5a418e))
+- Add explicit background to all elements ([54a3f5a](https://github.com/Khan/tota11y/commit/54a3f5a))
+- Skip the tota11y UI under the Landmarks plugin ([a3059e9](https://github.com/Khan/tota11y/commit/a3059e9))
+- Update jsdom and fix live-test script ([e5a418e](https://github.com/Khan/tota11y/commit/e5a418e))
 
 ## 0.1.3
 
-* Fixed npm build commands ([20cf3c4](https://github.com/Khan/tota11y/commit/20cf3c4))
-* Provide fallback for window.requestAnimationFrame on IE 9 and * under ([8d0aa4f](https://github.com/Khan/tota11y/commit/8d0aa4f))
-* Add bower.json file ([43fb990](https://github.com/Khan/tota11y/commit/43fb990))
-* Remove experimental ES7 code, and use babel for webpack config ([03a0021](https://github.com/Khan/tota11y/commit/03a0021))
-* Remove various hacks for unit testing ([048c873](https://github.com/Khan/tota11y/commit/048c873))
-* Fixed unit tests now that `window` is global ([492be3f](https://github.com/Khan/tota11y/commit/492be3f))
-* Fixed tests, ignoring ADT code from linter ([dd28057](https://github.com/Khan/tota11y/commit/dd28057))
+- Fixed npm build commands ([20cf3c4](https://github.com/Khan/tota11y/commit/20cf3c4))
+- Provide fallback for window.requestAnimationFrame on IE 9 and - under ([8d0aa4f](https://github.com/Khan/tota11y/commit/8d0aa4f))
+- Add bower.json file ([43fb990](https://github.com/Khan/tota11y/commit/43fb990))
+- Remove experimental ES7 code, and use babel for webpack config ([03a0021](https://github.com/Khan/tota11y/commit/03a0021))
+- Remove various hacks for unit testing ([048c873](https://github.com/Khan/tota11y/commit/048c873))
+- Fixed unit tests now that `window` is global ([492be3f](https://github.com/Khan/tota11y/commit/492be3f))
+- Fixed tests, ignoring ADT code from linter ([dd28057](https://github.com/Khan/tota11y/commit/dd28057))
 
 ## 0.1.2
 
-* Patch axs.AuditRule.collectMatchingElements to prevent JS errors with cross-origin iframes ([be1dc92](https://github.com/Khan/tota11y/commit/be1dc92))
+- Patch axs.AuditRule.collectMatchingElements to prevent JS errors with cross-origin iframes ([be1dc92](https://github.com/Khan/tota11y/commit/be1dc92))
 
 ## 0.1.1
 
-* Added keyboard accessibility to toolbar toggle ([861574e](https://github.com/Khan/tota11y/commit/861574e))
-* Change position code to work off left/top ([19cf161](https://github.com/Khan/tota11y/commit/19cf161))
-* Added architecture overview to README, and some dev installation instructions ([20115fd](https://github.com/Khan/tota11y/commit/20115fd))
+- Added keyboard accessibility to toolbar toggle ([861574e](https://github.com/Khan/tota11y/commit/861574e))
+- Change position code to work off left/top ([19cf161](https://github.com/Khan/tota11y/commit/19cf161))
+- Added architecture overview to README, and some dev installation instructions ([20115fd](https://github.com/Khan/tota11y/commit/20115fd))
 
 ## 0.1.0
 
-* Added an experimental "Magic wand" plugin to display screen-reader text on hover ([1215c6e](https://github.com/Khan/tota11y/commit/1215c6e), [fbcd665](https://github.com/Khan/tota11y/commit/fbcd665))
-* Upgrade tota11y to use Accessibility Developer Tools v2.9.0-rc0 ([fe9a070](https://github.com/Khan/tota11y/commit/fe9a070))
-* Fixed a bug in contrast preview when interacting with gradients ([4c4ea9d](https://github.com/Khan/tota11y/commit/4c4ea9d))
-* Fixed a bug with annotation toggling breaking the HeadingsPlugin summary tab ([2f6d9d6](https://github.com/Khan/tota11y/commit/2f6d9d6))
-* Added real `src` values to the AltTextPlugin suggestions ([053d066](https://github.com/Khan/tota11y/commit/053d066))
-* Added surrounding code to all error descriptions ([c044017](https://github.com/Khan/tota11y/commit/c044017))
-* Built a changelog!
+- Added an experimental "Magic wand" plugin to display screen-reader text on hover ([1215c6e](https://github.com/Khan/tota11y/commit/1215c6e), [fbcd665](https://github.com/Khan/tota11y/commit/fbcd665))
+- Upgrade tota11y to use Accessibility Developer Tools v2.9.0-rc0 ([fe9a070](https://github.com/Khan/tota11y/commit/fe9a070))
+- Fixed a bug in contrast preview when interacting with gradients ([4c4ea9d](https://github.com/Khan/tota11y/commit/4c4ea9d))
+- Fixed a bug with annotation toggling breaking the HeadingsPlugin summary tab ([2f6d9d6](https://github.com/Khan/tota11y/commit/2f6d9d6))
+- Added real `src` values to the AltTextPlugin suggestions ([053d066](https://github.com/Khan/tota11y/commit/053d066))
+- Added surrounding code to all error descriptions ([c044017](https://github.com/Khan/tota11y/commit/c044017))
+- Built a changelog!

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Include it right before `</body>` like so:
 
 Want to contribute to tota11y? Awesome! Run the following in your terminal:
 
-```
+```bash
 git clone https://github.com/Khan/tota11y.git
 cd tota11y/
 npm install
@@ -43,20 +43,20 @@ tota11y uses a variety of technologies, including [jQuery](https://jquery.com/),
 
 You can run unit tests on tota11y with the following:
 
-```
+```bash
 npm test
 ```
 
 Or lint with:
 
-```
+```bash
 npm run lint
 ```
 
 To perform manual testing as you work, you can run a live dev-server with the
 following:
 
-```
+```bash
 npm start
 ```
 
@@ -64,15 +64,29 @@ npm start
 
 To create a development build as the test server uses:
 
-```
+```bash
 npm run build:dev
 ```
 
 To create a production build, with minified and unminified output:
 
-```
+```bash
 npm run build:prod
 ```
+
+## Releasing
+
+Currently, the following steps must be made to release a new version of tota11y:
+
+1. Update `package.json` with the version number to be released.
+1. Commit the release details to the CHANGELOG.md.
+   This should be list of the unique pull requests and commits that contributed to the release (see the CHANGLOG.md file for previous examples).
+1. Draft a new release for the version.
+   The tag name and name of the release should be of the form `v1.2.3` where `1.2.3` is the version from `package.json`.
+1. Login to `npm` with the Khan Academy credentials.
+   This requires someone with appropriate privileges.
+1. Run `npm publish`.
+   This step will run tests and pre-publish checks, then perform a production build and publish the new package to NPM.
 
 ## Special thanks
 


### PR DESCRIPTION
When releasing v0.2.0, I didn't update the CHANGELOG.md nor create a Release. I've now created the release and this PR updates the CHANGELOG, but I thought it also would be useful for add some release instructions to the README.md so that these steps are less easily forgotten next time around.

It would be good to automate some of this long term, but for now, this is one step in the right direction.