### PR TITLE
Add support for heading role elements

### DIFF
--- a/plugins/headings/outline-item.handlebars
+++ b/plugins/headings/outline-item.handlebars
@@ -1,4 +1,4 @@
-<div class="tota11y-heading-outline-entry heading-level-{{level}}">
+<div class="tota11y-heading-outline-entry heading-level-{{_level}}">
     <span class="tota11y-heading-outline-level tota11y-label">{{level}}</span>
     <span class="tota11y-heading-outline-heading-text">{{text}}</span>
 </div>

--- a/plugins/headings/style.less
+++ b/plugins/headings/style.less
@@ -26,6 +26,9 @@
         &.heading-level-6 {
             margin-left: 100px;
         }
+        &.heading-level-higher {
+            margin-left: 100px;
+        }
 
     }
 

--- a/test/index.html
+++ b/test/index.html
@@ -120,7 +120,7 @@
                 <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
             </div>
             <div class="col-md-4">
-                <h2>Heading</h2>
+                <div role="heading" aria-level="2">ARIA Heading</div>
                 <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
                 <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
             </div>
@@ -137,7 +137,7 @@
                 <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
             </div>
             <div class="col-md-4">
-                <h2>Heading</h2>
+                <div role="heading" aria-level="7">Invalid ARIA Heading</div>
                 <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
                 <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
             </div>


### PR DESCRIPTION
This adds support for detecting and reporting on heading elements marked up as `role=heading aria-level=x` to the existing support for h1 - h6 elements to the headings plugin

Fixes https://github.com/Khan/tota11y/issues/156