### PR TITLE
Added examples integration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Currently, the following steps must be made to release a new version of tota11y:
    This requires someone with appropriate privileges.
 1. Run `npm publish`.
    This step will run tests and pre-publish checks, then perform a production build and publish the new package to NPM.
+   
+## Examples of Integration
+1. [webpack-react-typescript-project](https://github.com/azemetre/tota11y-webpack-react-typescript-example)
 
 ## Special thanks
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Currently, the following steps must be made to release a new version of tota11y:
 1. Run `npm publish`.
    This step will run tests and pre-publish checks, then perform a production build and publish the new package to NPM.
    
-## Examples of Integration
-1. [webpack-react-typescript-project](https://github.com/azemetre/tota11y-webpack-react-typescript-example)
+## Community Examples
+Want to integrate tota11y into your site, but don't know where to start? Here are some examples from the tota11y community to inspire you:
+* [azemetre/webpack-react-typescript-project](https://github.com/azemetre/tota11y-webpack-react-typescript-example) shows how to integrate tota11y into a webpack build for a React + TypeScript project.
 
 ## Special thanks
 


### PR DESCRIPTION
Hello!

We use tota11y where I work and we love the tool. I noticed that there was little documentation or examples of how to use tota11y online or in the README.

I included an `Examples of Integration` section so hopefully we can link to other github repo examples that showcase how to use tota11y in a variety of workflows in the future.

I created a repo showcasing just that for a react-typescript-webpack repo:

https://github.com/azemetre/tota11y-webpack-react-typescript-example

It would be useful to demonstrate how to use an awesome tool and properly link examples in the main README as well. 