### PR TITLE
Add new functionality

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -19,3 +19,159 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Added December 2020:
+
+portions of /plugins/contrast/index.js are "borrowed" from Mozilla code ( https://searchfox.org/mozilla-central/source/devtools/shared/accessibility.js#23) under MPL 2.0:
+
+Mozilla Public License
+Version 2.0
+1. Definitions
+1.1. “Contributor”
+means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+means
+
+that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
+
+that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
+
+1.6. “Executable Form”
+means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
+
+1.8. “License”
+means this document.
+
+1.9. “Licensable”
+means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
+
+1.10. “Modifications”
+means any of the following:
+
+any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
+
+any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+means an individual or a legal entity exercising rights under this License. For legal entities, “You” includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, “control” means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+2.1. Grants
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+
+2.2. Effective Date
+The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
+
+for any code that a Contributor has removed from Covered Software; or
+
+for infringements caused by: (i) Your and any other third party’s modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
+
+under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
+
+2.5. Representation
+Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+
+3. Responsibilities
+3.1. Distribution of Source Form
+All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+If You distribute Covered Software in Executable Form then:
+
+such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
+
+You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients’ rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
+
+3.4. Notices
+You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Termination
+5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
+
+6. Disclaimer of Warranty
+Covered Software is provided under this License on an “as is” basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.
+
+7. Limitation of Liability
+Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party’s negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+10.1. New Versions
+Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
+
+10.2. Effect of New Versions
+You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
+
+10.3. Modified Versions
+If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class Toolbar {
             $experimentalPlugins = (
                 <li>
                     <div className="tota11y-plugins-separator">
-                        Experimental
+                        Developers:
                     </div>
                     <ul>
                       {

--- a/less/base.less
+++ b/less/base.less
@@ -66,9 +66,15 @@
         margin: 0 0 10px;
     }
 
-    a, a:hover, a:focus {
+    a  {
         background-color: inherit;
-        color: inherit;
-        text-decoration: none;
-    }
+        color:#400099; // Babylon purple
+        text-decoration: underline;
+	}
+
+	a:hover, a:focus {text-decoration:none;}
+	a:visited {text-decoration: underline;}
+
 }
+
+

--- a/less/tota11y.less
+++ b/less/tota11y.less
@@ -53,3 +53,5 @@
     position: absolute;
     width: 1px;
 }
+
+.tota11y-label:hover {outline:1px red solid; z-index:9999;}

--- a/less/tota11y.less
+++ b/less/tota11y.less
@@ -10,8 +10,11 @@
     .position(fixed, auto, auto, 0, @viewportEdgePadding);
 
     border-top-left-radius: @borderRadius;
-    border-top-right-radius: @borderRadius;
-    overflow: hidden;
+	border-top-right-radius: @borderRadius;
+	/* make it scrollable vertically at 200% zoom */
+	overflow: scroll;
+	max-height:95%;
+	/* end hack */
     z-index: @z-index--UI;
 
     &-toggle {

--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -25,28 +25,32 @@ class A11yTextWand extends Plugin {
     $(document).on("mousemove.wand", function (e) {
       let element = document.elementFromPoint(e.clientX, e.clientY);
 
-			let textAlternative = axs.properties.findTextAlternatives(element, {});
+      let textAlternative = axs.properties.findTextAlternatives(element, {});
 
-// TODO: nasty Brucie hack: if this element is an img, grab its alt text and show that (otherwise textAlternative is blank for some reason). Ditto if it's an input with a value attribute, like WordPress search button <input type="submit" id="searchsubmit" value="Search"> )
+      // TODO: nasty Brucie hack: if this element is an img, grab its alt text and show that (otherwise textAlternative is blank for some reason). Ditto if it's an input with a value attribute, like WordPress search button <input type="submit" id="searchsubmit" value="Search"> )
 
+      //if ($(element).prop("nodeName") === "IMG" && element.hasAttribute("alt"))
+      //  {textAlternative +=" "+$(element).attr("alt");
+      //}
 
-//if ($(element).prop("nodeName") === "IMG" && element.hasAttribute("alt")) 
-//  {textAlternative +=" "+$(element).attr("alt");
-//}
-
-if ($(element).prop("nodeName") === "INPUT" && element.hasAttribute("value"))
-	{textAlternative = $(element).attr("value");}
-
-
-
-// TODO: test with fieldset and legend.
+      if (
+        $(element).prop("nodeName") === "INPUT" &&
+        element.hasAttribute("value")
+      ) {
+        if (!textAlternative) {
+          textAlternative = $(element).attr("value");
+        } else {
+          textAlternative += " " + $(element).attr("value");
+        }
+      }
+      // TODO: test with fieldset and legend.
 
       $(".tota11y-outlined").removeClass("tota11y-outlined");
       $(element).addClass("tota11y-outlined");
 
       // append anything found in aria-describedby, as screen readers will announce this too. It's a good way of adding accessible help text to form inputs— see https://developer.paciellogroup.com/blog/2014/12/using-aria-describedby-to-provide-helpful-form-hints/
 
-			const describedBy = $(element).attr("aria-describedby");
+      const describedBy = $(element).attr("aria-describedby");
       if (describedBy) {
         let describedIDs = describedBy.split(/\s/);
         for (const describedId of describedIDs) {

--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -41,7 +41,6 @@ class A11yTextWand extends Plugin {
         }
       }
 
-
       if (!textAlternative) {
         $(".tota11y-info-section.active").html(
           <i className="tota11y-nothingness">

--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -25,13 +25,27 @@ class A11yTextWand extends Plugin {
     $(document).on("mousemove.wand", function (e) {
       let element = document.elementFromPoint(e.clientX, e.clientY);
 
-      let textAlternative = axs.properties.findTextAlternatives(element, {});
+			let textAlternative = axs.properties.findTextAlternatives(element, {});
+
+// TODO: nasty Brucie hack: if this element is an img, grab its alt text and show that (otherwise textAlternative is blank for some reason). Ditto if it's an input with a value attribute, like WordPress search button <input type="submit" id="searchsubmit" value="Search"> )
+
+
+//if ($(element).prop("nodeName") === "IMG" && element.hasAttribute("alt")) 
+//  {textAlternative +=" "+$(element).attr("alt");
+//}
+
+if ($(element).prop("nodeName") === "INPUT" && element.hasAttribute("value"))
+	{textAlternative = $(element).attr("value");}
+
+
+
+// TODO: test with fieldset and legend.
 
       $(".tota11y-outlined").removeClass("tota11y-outlined");
       $(element).addClass("tota11y-outlined");
 
-      // append anything found in aria-describedby, as screen readers will //announce this too. It's a good way of adding accessible help text to form inputs— see https://developer.paciellogroup.com/blog/2014/12/using-aria-describedby-to-provide-helpful-form-hints/
-			
+      // append anything found in aria-describedby, as screen readers will announce this too. It's a good way of adding accessible help text to form inputs— see https://developer.paciellogroup.com/blog/2014/12/using-aria-describedby-to-provide-helpful-form-hints/
+
 			const describedBy = $(element).attr("aria-describedby");
       if (describedBy) {
         let describedIDs = describedBy.split(/\s/);
@@ -43,9 +57,9 @@ class A11yTextWand extends Plugin {
 
       if (!textAlternative) {
         $(".tota11y-info-section.active").html(
-          <i className="tota11y-nothingness">
-            No text visible to a screen reader
-          </i>
+          <strong className="tota11y-nothingness">
+            ** No text exposed to Assistive Tech! **
+          </strong>
         );
       } else {
         $(".tota11y-info-section.active").text(textAlternative);

--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -8,45 +8,56 @@ let Plugin = require("../base");
 require("./style.less");
 
 class A11yTextWand extends Plugin {
-    getTitle() {
-        return "Screen Reader Wand";
-    }
+  getTitle() {
+    return "Accessible name + description";
+  }
 
-    getDescription() {
-        return "Hover over elements to view them as a screen reader would";
-    }
+  getDescription() {
+    return "Hover over elements (e.g. form fields) to see accessible names & descriptions passed to assistive technology";
+  }
 
-    run() {
-        // HACK(jordan): We provide a fake summary to force the info panel to
-        //     render.
-        this.summary(" ");
-        this.panel.render();
+  run() {
+    // HACK(jordan): We provide a fake summary to force the info panel to
+    //     render.
+    this.summary(" ");
+    this.panel.render();
 
-        $(document).on("mousemove.wand", function(e) {
-            let element = document.elementFromPoint(e.clientX, e.clientY);
+    $(document).on("mousemove.wand", function (e) {
+      let element = document.elementFromPoint(e.clientX, e.clientY);
 
-            let textAlternative = axs.properties.findTextAlternatives(
-                element, {});
+      let textAlternative = axs.properties.findTextAlternatives(element, {});
 
-            $(".tota11y-outlined").removeClass("tota11y-outlined");
-            $(element).addClass("tota11y-outlined");
+      $(".tota11y-outlined").removeClass("tota11y-outlined");
+      $(element).addClass("tota11y-outlined");
 
-            if (!textAlternative) {
-                $(".tota11y-info-section.active").html(
-                    <i className="tota11y-nothingness">
-                        No text visible to a screen reader
-                    </i>
-                );
-            } else {
-                $(".tota11y-info-section.active").text(textAlternative);
-            }
-        });
-    }
+      // append anything found in aria-describedby, as screen readers will //announce this too. It's a good way of adding accessible help text to form inputs— see https://developer.paciellogroup.com/blog/2014/12/using-aria-describedby-to-provide-helpful-form-hints/
+			
+			const describedBy = $(element).attr("aria-describedby");
+      if (describedBy) {
+        let describedIDs = describedBy.split(/\s/);
+        for (const describedId of describedIDs) {
+          const el = document.getElementById(describedId);
+          if (el) textAlternative += " " + el.textContent;
+        }
+      }
 
-    cleanup() {
-        $(".tota11y-outlined").removeClass("tota11y-outlined");
-        $(document).off("mousemove.wand");
-    }
+
+      if (!textAlternative) {
+        $(".tota11y-info-section.active").html(
+          <i className="tota11y-nothingness">
+            No text visible to a screen reader
+          </i>
+        );
+      } else {
+        $(".tota11y-info-section.active").text(textAlternative);
+      }
+    });
+  }
+
+  cleanup() {
+    $(".tota11y-outlined").removeClass("tota11y-outlined");
+    $(document).off("mousemove.wand");
+  }
 }
 
 module.exports = A11yTextWand;

--- a/plugins/a11y-text-wand/index.js
+++ b/plugins/a11y-text-wand/index.js
@@ -27,11 +27,7 @@ class A11yTextWand extends Plugin {
 
       let textAlternative = axs.properties.findTextAlternatives(element, {});
 
-      // TODO: nasty Brucie hack: if this element is an img, grab its alt text and show that (otherwise textAlternative is blank for some reason). Ditto if it's an input with a value attribute, like WordPress search button <input type="submit" id="searchsubmit" value="Search"> )
-
-      //if ($(element).prop("nodeName") === "IMG" && element.hasAttribute("alt"))
-      //  {textAlternative +=" "+$(element).attr("alt");
-      //}
+      // nasty Brucie hack: if it's an input with a value attribute, like WordPress search button <input type="submit" id="searchsubmit" value="Search">, grab its velue text and show that (otherwise textAlternative is blank for some reason) )
 
       if (
         $(element).prop("nodeName") === "INPUT" &&
@@ -45,9 +41,6 @@ class A11yTextWand extends Plugin {
       }
       // TODO: test with fieldset and legend.
 
-      $(".tota11y-outlined").removeClass("tota11y-outlined");
-      $(element).addClass("tota11y-outlined");
-
       // append anything found in aria-describedby, as screen readers will announce this too. It's a good way of adding accessible help text to form inputs— see https://developer.paciellogroup.com/blog/2014/12/using-aria-describedby-to-provide-helpful-form-hints/
 
       const describedBy = $(element).attr("aria-describedby");
@@ -58,6 +51,9 @@ class A11yTextWand extends Plugin {
           if (el) textAlternative += " " + el.textContent;
         }
       }
+
+      $(".tota11y-outlined").removeClass("tota11y-outlined");
+      $(element).addClass("tota11y-outlined");
 
       if (!textAlternative) {
         $(".tota11y-info-section.active").html(

--- a/plugins/alt-text/index.js
+++ b/plugins/alt-text/index.js
@@ -60,7 +60,19 @@ class AltTextPlugin extends Plugin {
             elements.forEach(this.reportError.bind(this));
         }
 
-        // Additionally, label presentational images
+        //  present alt text for checking if attrib exists but not blank
+        $("img[alt]:not([alt=''])").each((i, el) => {
+            // "Error" labels have a warning icon and expanded text on hover,
+            // but we add a special `warning` class to color it differently.
+			let altMsg = "Check alt: " + $(el).attr("alt");
+
+			annotate
+                .errorLabel($(el), "Check!", $(el).attr("alt") )
+                .addClass("tota11y-label-warning");
+        });
+
+
+        //  label presentational images
         $("img[role=\"presentation\"], img[alt=\"\"]").each((i, el) => {
             // "Error" labels have a warning icon and expanded text on hover,
             // but we add a special `warning` class to color it differently.

--- a/plugins/alt-text/index.js
+++ b/plugins/alt-text/index.js
@@ -8,83 +8,92 @@ let annotate = require("../shared/annotate")("alt-text");
 let audit = require("../shared/audit");
 
 class AltTextPlugin extends Plugin {
-    getTitle() {
-        return "Image alt-text";
+  getTitle() {
+    return "Image alt-text";
+  }
+
+  getDescription() {
+    return "Annotates images without alt text";
+  }
+
+  reportError(el) {
+    let $el = $(el);
+    let src = $el.attr("src") || "..";
+    let title = "Image is missing alt text";
+    let $error = (
+      <div>
+        <p>
+          This image does not have an associated "alt" attribute. Please specify
+          the alt text for this image like so:
+        </p>
+
+        <pre>
+          <code>{`&lt;img src="${src}" alt="Image description"&gt`}</code>
+        </pre>
+
+        <p>
+          If the image is decorative and does not convey any information to the
+          surrounding content, however, you may leave this "alt" attribute
+          empty. See{" "}
+          <a
+            href="https://dna.babylonhealth.com/accessibility/elements/text-descriptions"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            DNA guidance on text descriptions
+          </a>
+          .
+        </p>
+
+        <pre>
+          <code>
+            {`&lt;img src="${src}" alt=""&gt;`}
+            <br />
+            {`&lt;img src="${src}" role="presentation"&gt;`}
+          </code>
+        </pre>
+      </div>
+    );
+
+    // Place an error label on the element and register it as an
+    // error in the info panel
+    let entry = this.error(title, $error, $el);
+    annotate.errorLabel($el, "", title, entry);
+  }
+
+  run() {
+    // Generate errors for any images that fail the Accessibility
+    // Developer Tools audit
+    let { result, elements } = audit("imagesWithoutAltText");
+
+    if (result === "FAIL") {
+      elements.forEach(this.reportError.bind(this));
     }
 
-    getDescription() {
-        return "Annotates images without alt text";
-    }
+    //  present alt text for checking if attrib exists but not blank
+    $("img[alt]:not([alt=''])").each((i, el) => {
+      // "Error" labels have a warning icon and expanded text on hover,
+      // but we add a special `warning` class to color it differently.
+      let altMsg = "Check alt: " + $(el).attr("alt");
 
-    reportError(el) {
-        let $el = $(el);
-        let src = $el.attr("src") || "..";
-        let title = "Image is missing alt text";
-        let $error = (
-            <div>
-                <p>
-                    This image does not have an associated "alt" attribute.
-                    Please specify the alt text for this image like so:
-                </p>
+      annotate
+        .errorLabel($(el), "Check!", $(el).attr("alt"))
+        .addClass("tota11y-label-warning");
+    });
 
-                <pre><code>
-                    {`&lt;img src="${src}" alt="Image description"&gt`}
-                </code></pre>
+    //  label presentational images
+    $('img[role="presentation"], img[alt=""]').each((i, el) => {
+      // "Error" labels have a warning icon and expanded text on hover,
+      // but we add a special `warning` class to color it differently.
+      annotate
+        .errorLabel($(el), "", "This image is decorative")
+        .addClass("tota11y-label-warning");
+    });
+  }
 
-                <p>
-                    If the image is decorative and does not convey any
-                    information to the surrounding content, however, you may
-                    leave this "alt" attribute empty. See <a href="https://dna.babylonhealth.com/accessibility/elements/text-descriptions" target="_blank" rel="noopener noreferrer">DNA guidance on text descriptions</a>.
-                </p>
-
-                <pre><code>
-                    {`&lt;img src="${src}" alt=""&gt;`}
-                    <br />
-                    {`&lt;img src="${src}" role="presentation"&gt;`}
-                </code></pre>
-            </div>
-        );
-
-        // Place an error label on the element and register it as an
-        // error in the info panel
-        let entry = this.error(title, $error, $el);
-        annotate.errorLabel($el, "", title, entry);
-    }
-
-    run() {
-        // Generate errors for any images that fail the Accessibility
-        // Developer Tools audit
-        let {result, elements} = audit("imagesWithoutAltText");
-
-        if (result === "FAIL") {
-            elements.forEach(this.reportError.bind(this));
-        }
-
-        //  present alt text for checking if attrib exists but not blank
-        $("img[alt]:not([alt=''])").each((i, el) => {
-            // "Error" labels have a warning icon and expanded text on hover,
-            // but we add a special `warning` class to color it differently.
-			let altMsg = "Check alt: " + $(el).attr("alt");
-
-			annotate
-                .errorLabel($(el), "Check!", $(el).attr("alt") )
-                .addClass("tota11y-label-warning");
-        });
-
-
-        //  label presentational images
-        $("img[role=\"presentation\"], img[alt=\"\"]").each((i, el) => {
-            // "Error" labels have a warning icon and expanded text on hover,
-            // but we add a special `warning` class to color it differently.
-            annotate
-                .errorLabel($(el), "", "This image is decorative")
-                .addClass("tota11y-label-warning");
-        });
-    }
-
-    cleanup() {
-        annotate.removeAll();
-    }
+  cleanup() {
+    annotate.removeAll();
+  }
 }
 
 module.exports = AltTextPlugin;

--- a/plugins/alt-text/index.js
+++ b/plugins/alt-text/index.js
@@ -34,8 +34,7 @@ class AltTextPlugin extends Plugin {
                 <p>
                     If the image is decorative and does not convey any
                     information to the surrounding content, however, you may
-                    leave this "alt" attribute empty, or specify a "role"
-                    attribute with a value of "presentation."
+                    leave this "alt" attribute empty. See <a href="https://dna.babylonhealth.com/accessibility/elements/text-descriptions" target="_blank" rel="noopener noreferrer">DNA guidance on text descriptions</a>.
                 </p>
 
                 <pre><code>

--- a/plugins/contrast/error-description.handlebars
+++ b/plugins/contrast/error-description.handlebars
@@ -35,5 +35,6 @@
             Preview:
             <input class="preview-contrast-fix" type="checkbox">
         </label>
+		<p>See <a href="https://dna.babylonhealth.com/accessibility/elements/colours-and-colour-contrast" target="_blank" rel="noopener noreferrer">DNA guidance on colours and colour contrast</a>.</p>
     </div>
 </div>

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -13,193 +13,209 @@ let descriptionTemplate = require("./error-description.handlebars");
 require("./style.less");
 
 class ContrastPlugin extends Plugin {
-    constructor() {
-        super();
-        // List of original colors for elements with insufficient contrast.
-        // Used to restore original colors in cleanup.
-        this.preservedColors = [];
-    }
+  constructor() {
+    super();
+    // List of original colors for elements with insufficient contrast.
+    // Used to restore original colors in cleanup.
+    this.preservedColors = [];
+  }
 
-    getTitle() {
-        return "Contrast";
-    }
+  getTitle() {
+    return "Contrast";
+  }
 
-    getDescription() {
-        return "Labels elements with insufficient contrast";
-    }
+  getDescription() {
+    return "Labels elements with insufficient contrast";
+  }
 
-    addError({style, fgColor, bgColor, contrastRatio, requiredRatio}, el) {
-        // Suggest colors at an "AA" level
-        let suggestedColors = axs.color.suggestColors(
-            bgColor,
-            fgColor,
-            { AA: requiredRatio }).AA;
+  addError({ style, fgColor, bgColor, contrastRatio, requiredRatio }, el) {
+    // Suggest colors at an "AA" level
+    let suggestedColors = axs.color.suggestColors(bgColor, fgColor, {
+      AA: requiredRatio,
+    }).AA;
 
-        let templateData = {
-            fgColorHex: axs.color.colorToString(fgColor),
-            bgColorHex: axs.color.colorToString(bgColor),
-            contrastRatio: contrastRatio,
-            requiredRatio: requiredRatio,
-            suggestedFgColorHex: suggestedColors.fg,
-            suggestedBgColorHex: suggestedColors.bg,
-            suggestedColorsRatio: suggestedColors.contrast
-        };
+    let templateData = {
+      fgColorHex: axs.color.colorToString(fgColor),
+      bgColorHex: axs.color.colorToString(bgColor),
+      contrastRatio: contrastRatio,
+      requiredRatio: requiredRatio,
+      suggestedFgColorHex: suggestedColors.fg,
+      suggestedBgColorHex: suggestedColors.bg,
+      suggestedColorsRatio: suggestedColors.contrast,
+    };
 
-        // Add click handler to preview checkbox
-        let $description = $(descriptionTemplate(templateData));
-        let originalFgColor = style.color;
-        let originalBgColor = style.backgroundColor;
+    // Add click handler to preview checkbox
+    let $description = $(descriptionTemplate(templateData));
+    let originalFgColor = style.color;
+    let originalBgColor = style.backgroundColor;
 
-        $description.find(".preview-contrast-fix").click((e) => {
-            if ($(e.target).prop("checked")) {
-                // Set suggested colors
-                $(el).css("color", suggestedColors.fg);
-                $(el).css("background-color", suggestedColors.bg);
-            } else {
-                // Set original colors
-                $(el).css("color", originalFgColor);
-                $(el).css("background-color", originalBgColor);
-            }
-        });
+    $description.find(".preview-contrast-fix").click((e) => {
+      if ($(e.target).prop("checked")) {
+        // Set suggested colors
+        $(el).css("color", suggestedColors.fg);
+        $(el).css("background-color", suggestedColors.bg);
+      } else {
+        // Set original colors
+        $(el).css("color", originalFgColor);
+        $(el).css("background-color", originalBgColor);
+      }
+    });
 
-        return this.error(
-            titleTemplate(templateData),
-            $description,
-            $(el));
-    }
+    return this.error(titleTemplate(templateData), $description, $(el));
+  }
 
-    run() {
-        // A map of fg/bg color pairs that we have already seen to the error
-        // entry currently present in the info panel
-        let combinations = {};
+  run() {
+    // A map of fg/bg color pairs that we have already seen to the error
+    // entry currently present in the info panel
+    let combinations = {};
 
-        $("*").each((i, el) => {
-            // Only check elements with a direct text descendant
-            if (!axs.properties.hasDirectTextDescendant(el)) {
-                return;
-            }
+    $("*").each((i, el) => {
+      // Only check elements with a direct text descendant
+      if (!axs.properties.hasDirectTextDescendant(el)) {
+        return;
+      }
 
-            // Ignore elements that are part of the tota11y UI
-            if ($(el).parents(".tota11y").length > 0) {
-                return;
-            }
+      // Ignore elements that are part of the tota11y UI
+      if ($(el).parents(".tota11y").length > 0) {
+        return;
+      }
 
-			// Ignore invisible elements
+      // Ignore invisible elements
 
-            if (axs.utils.elementIsTransparent(el) ||
-                axs.utils.elementHasZeroArea(el)) {
-                    return;
-            }
+      if (
+        axs.utils.elementIsTransparent(el) ||
+        axs.utils.elementHasZeroArea(el)
+      ) {
+        return;
+      }
 
-			let style = getComputedStyle(el);
+      let style = getComputedStyle(el);
 
-			// TODO also ignore 'visually hidden' things, eg https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
+      // Also ignore 'visually hidden' things, eg https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
 
-			const visuallyHidden = ((style.getPropertyValue("clip") == "rect(0px, 0px, 0px, 0px)") && (style.getPropertyValue("clip-path") == "inset(50%)") && (style.getPropertyValue("height") == "1px") && (style.getPropertyValue("overflow") == "hidden") &&  (style.getPropertyValue("position") == "absolute") && (style.getPropertyValue("white-space") == "nowrap") && (style.getPropertyValue("width") == "1px"))
+      const visuallyHidden =
+        style.getPropertyValue("clip") == "rect(0px, 0px, 0px, 0px)" && // even when zero, needs units
+        style.getPropertyValue("clip-path") == "inset(50%)" &&
+        style.getPropertyValue("height") == "1px" &&
+        style.getPropertyValue("overflow") == "hidden" &&
+        style.getPropertyValue("position") == "absolute" &&
+        style.getPropertyValue("white-space") == "nowrap" &&
+        style.getPropertyValue("width") == "1px";
 
-			if (visuallyHidden) {return};
+      if (visuallyHidden) {
+        return;
+      }
+      //
 
+      let bgColor = axs.utils.getBgColor(style, el);
+      let fgColor = axs.utils.getFgColor(style, el, bgColor);
 
-            let bgColor = axs.utils.getBgColor(style, el);
-			let fgColor = axs.utils.getFgColor(style, el, bgColor);
+      // Previous test used axs.utils.isLargeFont, which doesn't take bold text into account. This stolen from Mozilla under MPL 2.0 license https://searchfox.org/mozilla-central/source/devtools/shared/accessibility.js#23
 
-// Previous test used axs.utils.isLargeFont, which doesn't take bold text into account. This stolen from Mozilla uner MPL 2.0 license https://searchfox.org/mozilla-central/source/devtools/shared/accessibility.js#23
+      const isBoldText =
+        parseInt(style.getPropertyValue("font-weight"), 10) >= 600;
+      const size = parseFloat(style.getPropertyValue("font-size"));
 
-			const isBoldText = parseInt(style.getPropertyValue("font-weight"), 10) >= 600;
-			const size = parseFloat(style.getPropertyValue("font-size"));
+      const LARGE_TEXT = {
+        // CSS pixel value (constant) that corresponds to 14 point text size which defines large text when font text is bold (font weight is greater than or equal to 600).
+        BOLD_LARGE_TEXT_MIN_PIXELS: 18.66,
+        // CSS pixel value (constant) that corresponds to 18 point text size which defines large text for normal text (e.g. not bold).
+        LARGE_TEXT_MIN_PIXELS: 24,
+      };
 
-			const LARGE_TEXT = {
-				// CSS pixel value (constant) that corresponds to 14 point text size which defines large text when font text is bold (font weight is greater than or equal to 600).
-				BOLD_LARGE_TEXT_MIN_PIXELS: 18.66,
-				// CSS pixel value (constant) that corresponds to 18 point text size which defines large text for normal text (e.g. not bold).
-				LARGE_TEXT_MIN_PIXELS: 24,
-			  };
+      const isLargeText =
+        size >=
+        (isBoldText
+          ? LARGE_TEXT.BOLD_LARGE_TEXT_MIN_PIXELS
+          : LARGE_TEXT.LARGE_TEXT_MIN_PIXELS);
 
-  			const isLargeText = size >=(isBoldText
-      ? LARGE_TEXT.BOLD_LARGE_TEXT_MIN_PIXELS
-      : LARGE_TEXT.LARGE_TEXT_MIN_PIXELS);
+      // end Moz bit, need to replace the axs.utils below TODO
 
-// end Moz bit, need to replace the axs.utils below TODO
+      // Calculate required ratio based on size
+      // Using strings to prevent rounding
+      //          let requiredRatio = axs.utils.isLargeFont(style) ?
+      //				3.0 : 4.5;
 
-            // Calculate required ratio based on size
-            // Using strings to prevent rounding
-//          let requiredRatio = axs.utils.isLargeFont(style) ?
-//				3.0 : 4.5;
+      let requiredRatio = isLargeText ? 3.0 : 4.5;
 
-			let requiredRatio = isLargeText ?
-				3.0 : 4.5;
+      let contrastRatio = axs.color
+        .calculateContrastRatio(fgColor, bgColor)
+        .toFixed(2);
 
-            let contrastRatio = axs.color.calculateContrastRatio(
-				fgColor, bgColor).toFixed(2);
+      //				console.log(contrastRatio+" / reqd="+ requiredRatio);
 
-//				console.log(contrastRatio+" / reqd="+ requiredRatio);
+      // Build a key for our `combinations` map and report the color
+      // if we have not seen it yet
+      let key =
+        axs.color.colorToString(fgColor) +
+        "/" +
+        axs.color.colorToString(bgColor) +
+        "/" +
+        requiredRatio;
 
+      if (contrastRatio > requiredRatio) {
+        // For acceptable contrast values, we don't show ratios if
+        // they have been presented already
+        if (!combinations[key]) {
+          annotate
+            .label($(el), contrastRatio)
+            .addClass("tota11y-label-success");
 
-            // Build a key for our `combinations` map and report the color
-            // if we have not seen it yet
-            let key = axs.color.colorToString(fgColor) + "/" +
-                        axs.color.colorToString(bgColor) + "/" +
-                        requiredRatio;
+          // Add the key to the combinations map. We don't have an
+          // error to associate it with, so we'll just give it the
+          // value of `true`.
+          combinations[key] = true;
+        }
+      } else {
+        if (!combinations[key]) {
+          // We do not show duplicates in the errors panel, however,
+          // to keep the output from being overwhelming
+          let error = this.addError(
+            {
+              style,
+              fgColor,
+              bgColor,
+              contrastRatio,
+              requiredRatio,
+            },
+            el
+          );
 
-            if (contrastRatio > requiredRatio ) {
-                // For acceptable contrast values, we don't show ratios if
-                // they have been presented already
-                if (!combinations[key]) {
-                    annotate
-                        .label($(el), contrastRatio)
-                        .addClass("tota11y-label-success");
+          // Save original color so it can be restored on cleanup.
+          this.preservedColors.push({
+            $el: $(el),
+            fg: style.color,
+            bg: style.backgroundColor,
+          });
 
-                    // Add the key to the combinations map. We don't have an
-                    // error to associate it with, so we'll just give it the
-                    // value of `true`.
-                    combinations[key] = true;
-                }
-            } else {
-                if (!combinations[key]) {
-                    // We do not show duplicates in the errors panel, however,
-                    // to keep the output from being overwhelming
-                    let error = this.addError({
-                        style,
-                        fgColor,
-                        bgColor,
-                        contrastRatio,
-                        requiredRatio,
-                    }, el);
+          combinations[key] = error;
+        }
 
-                    // Save original color so it can be restored on cleanup.
-                    this.preservedColors.push({
-                        $el: $(el),
-                        fg: style.color,
-                        bg: style.backgroundColor,
-                    });
+        // We display errors multiple times for emphasis. Each error
+        // will point back to the entry in the info panel for that
+        // particular color combination.
+        //
+        // TODO: The error entry in the info panel will only highlight
+        // the first element with that color combination
+        annotate.errorLabel(
+          $(el),
+          contrastRatio,
+          "This contrast is insufficient at this size.",
+          combinations[key]
+        );
+      }
+    });
+  }
 
-                    combinations[key] = error;
-                }
+  cleanup() {
+    // Set all elements to original color
+    this.preservedColors.forEach((entry) => {
+      entry.$el.css("color", entry.fg);
+      entry.$el.css("background-color", entry.bg);
+    });
 
-                // We display errors multiple times for emphasis. Each error
-                // will point back to the entry in the info panel for that
-                // particular color combination.
-                //
-                // TODO: The error entry in the info panel will only highlight
-                // the first element with that color combination
-                annotate.errorLabel(
-                    $(el),
-                    contrastRatio,
-                    "This contrast is insufficient at this size.",
-                    combinations[key]);
-            }
-        });
-    }
-
-    cleanup() {
-        // Set all elements to original color
-        this.preservedColors.forEach((entry) => {
-            entry.$el.css("color", entry.fg);
-            entry.$el.css("background-color", entry.bg);
-        });
-
-        annotate.removeAll();
-    }
+    annotate.removeAll();
+  }
 }
 
 module.exports = ContrastPlugin;

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -91,7 +91,7 @@ class ContrastPlugin extends Plugin {
 
       let style = getComputedStyle(el);
 
-      // Also ignore 'visually hidden' things, eg https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
+      // ignore 'visually hidden' things, eg https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
 
       const visuallyHidden =
         style.getPropertyValue("clip") == "rect(0px, 0px, 0px, 0px)" && // even when zero, needs units
@@ -102,9 +102,10 @@ class ContrastPlugin extends Plugin {
         style.getPropertyValue("white-space") == "nowrap" &&
         style.getPropertyValue("width") == "1px";
 
-      if (visuallyHidden) {
-        return;
-      }
+      // Also ignore text with opacity:0 as found on guardian.co.uk, amazon.co.uk
+
+      if (visuallyHidden || style.getPropertyValue("opacity") == "0") return;
+      
       //
 
       let bgColor = axs.utils.getBgColor(style, el);

--- a/plugins/contrast/index.js
+++ b/plugins/contrast/index.js
@@ -85,13 +85,21 @@ class ContrastPlugin extends Plugin {
             }
 
 			// Ignore invisible elements
-			// TODO also ignore 'visually hidden' things, eg https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
+
             if (axs.utils.elementIsTransparent(el) ||
                 axs.utils.elementHasZeroArea(el)) {
                     return;
             }
 
 			let style = getComputedStyle(el);
+
+			// TODO also ignore 'visually hidden' things, eg https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
+
+			const visuallyHidden = ((style.getPropertyValue("clip") == "rect(0px, 0px, 0px, 0px)") && (style.getPropertyValue("clip-path") == "inset(50%)") && (style.getPropertyValue("height") == "1px") && (style.getPropertyValue("overflow") == "hidden") &&  (style.getPropertyValue("position") == "absolute") && (style.getPropertyValue("white-space") == "nowrap") && (style.getPropertyValue("width") == "1px"))
+
+			if (visuallyHidden) {return};
+
+
             let bgColor = axs.utils.getBgColor(style, el);
 			let fgColor = axs.utils.getFgColor(style, el, bgColor);
 

--- a/plugins/empty/index.js
+++ b/plugins/empty/index.js
@@ -2,7 +2,7 @@
  * A plugin to identify empty elements, esp those to fake styling
  *  <p>, <h1..6>, <li>, <ol>, <ul> and <br><br>
  * do we need to strip out &nbsp too? TODO
- * 
+ *
  * TODO: add tests on dummy index page for these
  */
 
@@ -28,6 +28,7 @@ class EmptyElementsPlugin extends Plugin {
     }
 	run() {
 		  $("p:empty, h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty, li:empty, ol:empty, ul:empty, br+br").each(function () {
+			$(this).append("EMPTY ELEMENT");
 			annotate.label($(this), $(this).prop("tagName"));
 		});
 
@@ -35,7 +36,7 @@ class EmptyElementsPlugin extends Plugin {
 
 	  cleanup() {
 		annotate.removeAll();
-	
+
 	  }
 	}
 

--- a/plugins/empty/index.js
+++ b/plugins/empty/index.js
@@ -27,11 +27,17 @@ class EmptyElementsPlugin extends Plugin {
         `;
     }
 	run() {
-		  $("p:empty, h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty, li:empty, ol:empty, ul:empty, br+br").each(function () {
+		  $("h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty, li:empty, ol:empty, ul:empty, nav:empty, header:empty, main:empty, aside:empty, footer:empty, figcaption:empty").each(function () {
 			$(this).append("EMPTY ELEMENT !!");
+			$(this).addClass("tota11y-empty"); // so we can find them again
+			annotate.errorLabel($(this),"Empty!", $(this).prop("tagName"));
+		});
+
+		$("p:empty, br+br").each(function () {
 			$(this).addClass("tota11y-empty"); // so we can find them again
 			annotate.label($(this), $(this).prop("tagName"));
 		});
+
 
 	  }
 

--- a/plugins/empty/index.js
+++ b/plugins/empty/index.js
@@ -28,7 +28,8 @@ class EmptyElementsPlugin extends Plugin {
     }
 	run() {
 		  $("p:empty, h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty, li:empty, ol:empty, ul:empty, br+br").each(function () {
-			$(this).append("EMPTY ELEMENT");
+			$(this).append("EMPTY ELEMENT !!");
+			$(this).addClass("tota11y-empty"); // so we can find them again
 			annotate.label($(this), $(this).prop("tagName"));
 		});
 
@@ -36,9 +37,10 @@ class EmptyElementsPlugin extends Plugin {
 
 	  cleanup() {
 		annotate.removeAll();
-
+		$(".tota11y-empty").each(function () {
+			$(this).empty();
+		});
 	  }
 	}
-
 
 module.exports = EmptyElementsPlugin;

--- a/plugins/empty/index.js
+++ b/plugins/empty/index.js
@@ -1,0 +1,43 @@
+/**
+ * A plugin to identify empty elements, esp those to fake styling
+ *  <p>, <h1..6>, <li>, <ol>, <ul> and <br><br>
+ * do we need to strip out &nbsp too? TODO
+ * 
+ * TODO: add tests on dummy index page for these
+ */
+
+
+let $ = require("jquery");
+let Plugin = require("../base");
+let annotate = require("../shared/annotate")("landmarks");
+
+
+let outlineItemTemplate = require("./index.js");
+require("./index.js");
+
+
+class EmptyElementsPlugin extends Plugin {
+    getTitle() {
+        return "Empty elements";
+    }
+
+    getDescription() {
+        return `
+            Highlights empty elements that should be removed
+        `;
+    }
+	run() {
+		  $("p:empty, h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty, li:empty, ol:empty, ul:empty, br+br").each(function () {
+			annotate.label($(this), $(this).prop("tagName"));
+		});
+
+	  }
+
+	  cleanup() {
+		annotate.removeAll();
+	
+	  }
+	}
+
+
+module.exports = EmptyElementsPlugin;

--- a/plugins/headings/index.js
+++ b/plugins/headings/index.js
@@ -15,10 +15,10 @@ const ERRORS = {
             title: "First heading is not an &lt;h1&gt;",
             description: `
                 <div>
-                    To give your document a proper structure for assistive
-                    technologies, it is important to lay out your headings
+                    To give your page a proper structure for assistive
+                    technologies, lay out your headings
                     beginning with an <code>&lt;h1&gt;</code>. We found an
-                    <code>&lt;h${level}&gt;</code> instead.
+                    <code>&lt;h${level}&gt;</code> instead. See <a href="https://dna.babylonhealth.com/accessibility/elements/headings" target="_blank" rel="noopener noreferrer">DNA guidance for Headings</a>.
                 </div>
             `
         };
@@ -44,9 +44,8 @@ const ERRORS = {
         let _tag = (level) => `<code>&lt;h${level}&gt;</code>`;
         let description = `
             <div>
-                This document contains an ${_tag(currLevel)} tag directly
-                following an ${_tag(prevLevel)}. In order to maintain a consistent
-                outline of the page for assistive technologies, reduce the gap in
+                <p>This page contains an ${_tag(currLevel)} tag directly
+                following an ${_tag(prevLevel)}. Reduce the gap in
                 the heading level by upgrading this tag to an
                 ${_tag(prevLevel+1)}`;
 
@@ -56,7 +55,7 @@ const ERRORS = {
             description += ` or ${_tag(prevLevel)}`;
         }
 
-        description += ".</div>";
+        description += ". See <a href='https://dna.babylonhealth.com/accessibility/elements/headings' target='_blank' rel='noopener noreferrer'>DNA guidance for Headings</a>.</div>";
 
         return {
             title: `

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -17,12 +17,13 @@ module.exports = {
         new HeadingsPlugin(),
         new ContrastPlugin(),
         new LinkTextPlugin(),
-        new LabelsPlugin(),
         new AltTextPlugin(),
-        new LandmarksPlugin(),
     ],
 
     experimental: [
-        new A11yTextWand(),
+		new LabelsPlugin(),
+		new LandmarksPlugin(),
+		new A11yTextWand(),
+
     ],
 };

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -9,6 +9,7 @@ let ContrastPlugin = require("./contrast");
 let HeadingsPlugin = require("./headings");
 //let LabelsPlugin = require("./labels");
 let LandmarksPlugin = require("./landmarks");
+let TitlesPlugin = require("./titles");
 let LinkTextPlugin = require("./link-text");
 let A11yTextWand = require("./a11y-text-wand");
 let EmptyElementsPlugin = require("./empty");
@@ -25,6 +26,7 @@ module.exports = {
     experimental: [
 	//	new LabelsPlugin(),
 		new LandmarksPlugin(),
+		new TitlesPlugin(),
 		new A11yTextWand()
     ],
 };

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -7,23 +7,24 @@
 let AltTextPlugin = require("./alt-text");
 let ContrastPlugin = require("./contrast");
 let HeadingsPlugin = require("./headings");
-let LabelsPlugin = require("./labels");
+//let LabelsPlugin = require("./labels");
 let LandmarksPlugin = require("./landmarks");
 let LinkTextPlugin = require("./link-text");
 let A11yTextWand = require("./a11y-text-wand");
+let EmptyElementsPlugin = require("./empty");
 
 module.exports = {
     default: [
         new HeadingsPlugin(),
         new ContrastPlugin(),
         new LinkTextPlugin(),
-        new AltTextPlugin(),
+				new AltTextPlugin(),
+				new EmptyElementsPlugin()
     ],
 
     experimental: [
-		new LabelsPlugin(),
+	//	new LabelsPlugin(),
 		new LandmarksPlugin(),
-		new A11yTextWand(),
-
+		new A11yTextWand()
     ],
 };

--- a/plugins/labels/error-template.handlebars
+++ b/plugins/labels/error-template.handlebars
@@ -1,7 +1,7 @@
 {{#if placeholder}}
     <p>
         The <code>placeholder</code> attribute is not guaranteed to be read by
-        assistive technologies. It is better to include a proper label.
+        assistive technologies. It is better to include a proper label. See <a href="https://dna.babylonhealth.com/ui-guidelines/components/text-input" target='_blank' rel='noopener noreferrer'>DNA guidelines on labels</a>.
     </p>
 {{/if}}
 

--- a/plugins/landmarks/index.js
+++ b/plugins/landmarks/index.js
@@ -5,25 +5,35 @@
 let $ = require("jquery");
 let Plugin = require("../base");
 let annotate = require("../shared/annotate")("landmarks");
+require("./style.less");
 
 class LandmarksPlugin extends Plugin {
-    getTitle() {
-        return "Landmarks";
-    }
+  getTitle() {
+    return "Landmarks";
+  }
 
-    getDescription() {
-        return "Labels all ARIA landmarks";
-    }
+  getDescription() {
+    return "Labels set ARIA roles, outlines HTML landmarks";
+  }
 
-    run() {
-        $("[role]:not(.tota11y-toolbar,.tota11y-plugin)").each(function() {
-            annotate.label($(this), $(this).attr("role"));
-        });
-    }
+  run() {
+    $("[role]:not(.tota11y-toolbar,.tota11y-plugin)").each(function () {
+      annotate.label($(this), $(this).attr("role"));
+    });
 
-    cleanup() {
-        annotate.removeAll();
-    }
+    $("header, footer, nav, aside, main").each(function () {
+      annotate.label($(this), $(this).prop("tagName"));
+      $(this).addClass("tota11y-element-outlined");
+    });
+  }
+
+  cleanup() {
+    annotate.removeAll();
+
+    $(".tota11y-element-outlined").each(function () {
+      $(this).removeClass("tota11y-element-outlined");
+    });
+  }
 }
 
 module.exports = LandmarksPlugin;

--- a/plugins/landmarks/index.js
+++ b/plugins/landmarks/index.js
@@ -9,7 +9,7 @@ require("./style.less");
 
 class LandmarksPlugin extends Plugin {
   getTitle() {
-    return "Landmarks";
+    return "Landmarks, ARIA roles";
   }
 
   getDescription() {

--- a/plugins/landmarks/style.less
+++ b/plugins/landmarks/style.less
@@ -1,0 +1,2 @@
+
+.tota11y-element-outlined {outline:3px dashed red}

--- a/plugins/link-text/index.js
+++ b/plugins/link-text/index.js
@@ -14,8 +14,7 @@ class LinkTextPlugin extends Plugin {
 
     getDescription() {
         return `
-            Identifies links that may be confusing when read by a screen
-            reader
+            Identifies links that may be confusing because they lack context
         `;
     }
 
@@ -90,12 +89,11 @@ class LinkTextPlugin extends Plugin {
                         {" "}
                         <i>"{extractedText}"</i>
                         {" "}
-                        is unclear without context and may be confusing to
-                        screen readers. Consider rearranging the
+                        is unclear without context and may be confusing. See <a target="_blank" rel="noopener noreferrer" href="https://dna.babylonhealth.com/ui-guidelines/components/text-link">DNA guidance on link text</a>. Consider rearranging the
                         {" "}
                         <code>{"&lt;a&gt;&lt;/a&gt;"}</code>
                         {" "}
-                        tags or including special screen reader text.
+                        tags or using <code>aria-label</code>.
                     </div>
                 );
 

--- a/plugins/titles/index.js
+++ b/plugins/titles/index.js
@@ -33,7 +33,8 @@ class TitlesPlugin extends Plugin {
   }
 
 	cleanup() {
-		annotate.removeAll();
+		$(".tota11y-annotation-Title").remove()
+//		annotate.removeAll(); hacked with above b/c namespace in /shared/annotate/index.js
 }
 }
 

--- a/plugins/titles/index.js
+++ b/plugins/titles/index.js
@@ -4,7 +4,7 @@
 
 let $ = require("jquery");
 let Plugin = require("../base");
-let annotate = require("../shared/annotate")("zonk");
+let annotate = require("../shared/annotate")("Title attributes");
 require("./style.less");
 
 class TitlesPlugin extends Plugin {
@@ -17,23 +17,24 @@ class TitlesPlugin extends Plugin {
   }
 
   run() {
-    $("[role]:not(.tota11y-toolbar,.tota11y-plugin)").each(function () {
-      annotate.label($(this), $(this).attr("role"));
+    $("[title]").each(function () {
+      if ($(this).prop("tagName") !== "IFRAME") {
+        annotate
+          .label($(this), $(this).attr("title"))
+          .addClass("tota11y-label-warning");
+      }
     });
 
-    $("header, footer, nav, aside, main").each(function () {
-      annotate.label($(this), $(this).prop("tagName"));
-      $(this).addClass("tota11y-element-outlined");
-    });
-  }
-
-  cleanup() {
-    annotate.removeAll();
-
-    $(".tota11y-element-outlined").each(function () {
-      $(this).removeClass("tota11y-element-outlined");
+    $("iframe").each(function () {
+      if (!this.hasAttribute("title")) {
+        annotate.errorLabel($(this), "Error", "iframe with no title", "");
+      }
     });
   }
+
+	cleanup() {
+		annotate.removeAll();
+}
 }
 
-module.exports = LandmarksPlugin;
+module.exports = TitlesPlugin;

--- a/plugins/titles/index.js
+++ b/plugins/titles/index.js
@@ -1,0 +1,39 @@
+/**
+ * A plugin to label all ARIA landmark roles
+ */
+
+let $ = require("jquery");
+let Plugin = require("../base");
+let annotate = require("../shared/annotate")("zonk");
+require("./style.less");
+
+class TitlesPlugin extends Plugin {
+  getTitle() {
+    return "Title attributes";
+  }
+
+  getDescription() {
+    return "Labels redundant and missing title attributes";
+  }
+
+  run() {
+    $("[role]:not(.tota11y-toolbar,.tota11y-plugin)").each(function () {
+      annotate.label($(this), $(this).attr("role"));
+    });
+
+    $("header, footer, nav, aside, main").each(function () {
+      annotate.label($(this), $(this).prop("tagName"));
+      $(this).addClass("tota11y-element-outlined");
+    });
+  }
+
+  cleanup() {
+    annotate.removeAll();
+
+    $(".tota11y-element-outlined").each(function () {
+      $(this).removeClass("tota11y-element-outlined");
+    });
+  }
+}
+
+module.exports = LandmarksPlugin;

--- a/plugins/titles/style.less
+++ b/plugins/titles/style.less
@@ -1,0 +1,2 @@
+
+.tota11y-element-outlined {outline:3px dashed red}

--- a/test/index.html
+++ b/test/index.html
@@ -1,182 +1,219 @@
 <!doctype html>
 <html>
+
 <head>
-    <title>tota11y testbed</title>
-    <style>
-        body {
-            font-family: Arial;
-        }
+	<title>tota11y testbed</title>
+	<style>
+		body {
+			font-family: Arial;
+		}
 
-        .gradient {
-            background-image: linear-gradient(to bottom, #2937FF 0%, #6EFFCF 100%);
-            padding: 40px;
-            text-align: center;
-            width: 400px;
-        }
+		.gradient {
+			background-image: linear-gradient(to bottom, #2937FF 0%, #6EFFCF 100%);
+			padding: 40px;
+			text-align: center;
+			width: 400px;
+		}
 
-        .gradient .text {
-            color: white;
-            font-size: 24px;
-            font-weight: bold;
-        }
-    </style>
-    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
+		.gradient .text {
+			color: white;
+			font-size: 24px;
+			font-weight: bold;
+		}
+	</style>
+	<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
 </head>
+
 <body>
-    <nav class="navbar navbar-inverse navbar-fixed-top">
-        <div class="container">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-                <h4 class="navbar-brand">Project name</h4>
-            </div>
-            <div id="navbar" class="navbar-collapse collapse">
-                <form class="navbar-form navbar-right">
-                    <div class="form-group">
-                        <input id="email" type="text" placeholder="Email" class="form-control">
-                    </div>
-                    <div class="form-group">
-                        <input type="password" placeholder="Password" class="form-control">
-                    </div>
-                    <button type="submit" class="btn btn-success">Sign in</button>
-                </form>
-            </div><!--/.navbar-collapse -->
-        </div>
-    </nav>
+	<nav class="navbar navbar-inverse navbar-fixed-top">
+		<div class="container">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar"
+					aria-expanded="false" aria-controls="navbar">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+				</button>
+				<h4 class="navbar-brand">Project name</h4>
+			</div>
+			<div id="navbar" class="navbar-collapse collapse">
+				<form class="navbar-form navbar-right">
+					<div class="form-group">
+						<input id="email" type="text" placeholder="Email" class="form-control" aria-label="Email label">
+					</div>
+					<div class="form-group">
+						<input type="password" placeholder="Password" class="form-control" aria-labelledby="btn">
+					</div>
+					<button id=btn type="submit" class="btn btn-success">Sign in</button>
+				</form>
+			</div>
+			<!--/.navbar-collapse -->
+		</div>
+	</nav>
 
-    <!-- Main jumbotron for a primary marketing message or call to action -->
-    <div class="jumbotron">
-        <div class="container">
-            <h1>Hello, world!</h1>
-            <p>This is a template for a simple marketing or informational website. It includes a large callout called a jumbotron and three supporting pieces of content. Use it as a starting point to create something more unique.</p>
-            <p>
-                <a href="#">Click here</a> to see why. Or <a href="#">check out more demo pages</a> on my blog.
-            </p>
-            <p><a class="btn btn-primary btn-lg" href="#" role="button">Learn more &raquo;</a></p>
+	<!-- Main jumbotron for a primary marketing message or call to action -->
+	<div class="jumbotron">
+		<div class="container">
+			<h1>Hello, world!</h1>
+			<p>This is a template for a simple marketing or informational website. It includes a large callout called a
+				jumbotron and three supporting pieces of content. Use it as a starting point to create something more
+				unique.</p>
+			<p>
+				<a href="#">Click here</a> to see why. Or <a href="#">check out more demo pages</a> on my blog.
+			</p>
+			<p><a class="btn btn-primary btn-lg" href="#" role="button">Learn more &raquo;</a></p>
 
-            <p><a class="btn btn-primary btn-lg btn-success" href="#" role="button">Continue</a></p>
+			<p><a class="btn btn-primary btn-lg btn-success" href="#" role="button">Continue</a></p>
 
-            <p>
-                <img width="40px" height="40px" src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" alt="jordan">
-                <img width="40px" height="40px" src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" alt="">
-                <img width="40px" height="40px" src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" role="presentation">
-                <img width="40px" height="40px" src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256">
-            </p>
+			<p>
+				<img width="40px" height="40px"
+					src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" alt="jordan">
+				<img width="40px" height="40px"
+					src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" alt="">
+				<img width="40px" height="40px"
+					src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256" role="presentation">
+				<img width="40px" height="40px"
+					src="http://s.gravatar.com/avatar/3517596df161030c3779c532f7844383?s=256">
+			</p>
 
-            <p>
-                <a href="http://khan.github.io/tota11y">
-                    <img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67" alt="About this page" width="50">
-                </a>
-                <a href="http://khan.github.io/tota11y">
-                    <img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67" alt="Check out tota11y" width="50">
-                </a>
-            </p>
+			<p>
+				<a href="http://khan.github.io/tota11y">
+					<img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67"
+						alt="About this page" width="50">
+				</a>
+				<a href="http://khan.github.io/tota11y">
+					<img src="https://camo.githubusercontent.com/cbd869e1eaca0ce98cb7e8d7eb28a6d845a18362/687474703a2f2f6b68616e2e6769746875622e696f2f746f74613131792f696d672f746f74613131792d6c6f676f2e706e67"
+						alt="Check out tota11y" width="50">
+				</a>
+			</p>
 
-            <div class="gradient">
-                <div class="text">
-                    This text has a gradient
-                </div>
-            </div>
+			<div class="gradient">
+				<div class="text">
+					This text has a gradient
+				</div>
+			</div>
 
-            <div class="social">
-                <ul class="social-buttons">
-                    <li>
-                        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=Khan&amp;repo=tota11y&amp;type=watch&amp;count=true" width="95" height="20" title="Star on GitHub"></iframe>
-                    </li>
-                    <li>
-                        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=Khan&amp;repo=tota11y&amp;type=fork&amp;count=true" width="86" height="20" title="Fork on GitHub"></iframe>
-                    </li>
-                    <li class="follow-btn">
-                        <iframe id="twitter-widget-1" scrolling="no" frameborder="0" allowtransparency="true" src="http://platform.twitter.com/widgets/follow_button.53db0107b4b6a3bad3794c3440f5809f.en.html#_=1433768369078&amp;dnt=false&amp;id=twitter-widget-1&amp;lang=en&amp;screen_name=tota11y&amp;show_count=true&amp;show_screen_name=true&amp;size=m" class="twitter-follow-button twitter-follow-button" title="Twitter Follow Button" data-twttr-rendered="true" style="position: static; visibility: visible; width: 190px; height: 20px;"></iframe>
-                    </li>
-                    <li class="tweet-btn">
-                        <!--<iframe id="twitter-widget-0" scrolling="no" frameborder="0" allowtransparency="true" src="http://platform.twitter.com/widgets/tweet_button.54460a335ba528591a034cfb509bdf51.en.html#_=1433768369073&amp;count=horizontal&amp;dnt=false&amp;id=twitter-widget-0&amp;lang=en&amp;original_referer=http%3A%2F%2Fgetbootstrap.com%2F&amp;related=mdo%3ACreator%20of%20Bootstrap&amp;size=m&amp;text=Bootstrap%20%C2%B7%20The%20world%27s%20most%20popular%20mobile-first%20and%20responsive%20front-end%20framework.&amp;url=http%3A%2F%2Fgetbootstrap.com%2F&amp;via=getbootstrap" class="twitter-share-button twitter-tweet-button twitter-share-button twitter-count-horizontal" title="Twitter Tweet Button" data-twttr-rendered="true" style="position: static; visibility: visible; width: 97px; height: 20px;"></iframe>
+			<div class="social">
+				<ul class="social-buttons">
+					<li>
+						<iframe class="github-btn"
+							src="http://ghbtns.com/github-btn.html?user=Khan&amp;repo=tota11y&amp;type=watch&amp;count=true"
+							width="95" height="20" title="Star on GitHub"></iframe>
+					</li>
+					<li>
+						<iframe class="github-btn"
+							src="http://ghbtns.com/github-btn.html?user=Khan&amp;repo=tota11y&amp;type=fork&amp;count=true"
+							width="86" height="20" title="Fork on GitHub"></iframe>
+					</li>
+					<li class="follow-btn">
+						<iframe id="twitter-widget-1" scrolling="no" frameborder="0" allowtransparency="true"
+							src="http://platform.twitter.com/widgets/follow_button.53db0107b4b6a3bad3794c3440f5809f.en.html#_=1433768369078&amp;dnt=false&amp;id=twitter-widget-1&amp;lang=en&amp;screen_name=tota11y&amp;show_count=true&amp;show_screen_name=true&amp;size=m"
+							class="twitter-follow-button twitter-follow-button" title="Twitter Follow Button"
+							data-twttr-rendered="true"
+							style="position: static; visibility: visible; width: 190px; height: 20px;"></iframe>
+					</li>
+					<li class="tweet-btn">
+						<!--<iframe id="twitter-widget-0" scrolling="no" frameborder="0" allowtransparency="true" src="http://platform.twitter.com/widgets/tweet_button.54460a335ba528591a034cfb509bdf51.en.html#_=1433768369073&amp;count=horizontal&amp;dnt=false&amp;id=twitter-widget-0&amp;lang=en&amp;original_referer=http%3A%2F%2Fgetbootstrap.com%2F&amp;related=mdo%3ACreator%20of%20Bootstrap&amp;size=m&amp;text=Bootstrap%20%C2%B7%20The%20world%27s%20most%20popular%20mobile-first%20and%20responsive%20front-end%20framework.&amp;url=http%3A%2F%2Fgetbootstrap.com%2F&amp;via=getbootstrap" class="twitter-share-button twitter-tweet-button twitter-share-button twitter-count-horizontal" title="Twitter Tweet Button" data-twttr-rendered="true" style="position: static; visibility: visible; width: 97px; height: 20px;"></iframe>
                         -->
-                        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://khan.github.io/tota11y" data-text="tota11y – an accessibility visualization toolkit by @KhanAcademy">Tweet</a>
-                        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </div>
+						<a href="https://twitter.com/share" class="twitter-share-button"
+							data-url="http://khan.github.io/tota11y"
+							data-text="tota11y – an accessibility visualization toolkit by @KhanAcademy">Tweet</a>
+						<script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https'; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + '://platform.twitter.com/widgets.js'; fjs.parentNode.insertBefore(js, fjs); } }(document, 'script', 'twitter-wjs');</script>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</div>
 
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <h3>Invalid Subheading</h3>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-        </div>
-        <!-- Example row of columns -->
-        <div class="row">
-            <div class="col-md-4">
-                <h2>Heading</h2>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-            <div class="col-md-4">
-                <h2>Heading</h2>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-            <div class="col-md-4">
-                <h4>Invalid Subheading</h4>
-                <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-4">
-                <h2>Heading</h2>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-            <div class="col-md-4">
-                <h2>Heading</h2>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-            <div class="col-md-4">
-                <h2>Subheading</h2>
-                <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-        </div>
+	<div class="container">
+		<div class="row">
+			<div class="col-md-12">
+				<h3>Invalid Subheading</h3>
+				<p>Button describedby two different IDs: </p>
+				<p><a class="btn btn-default" href="#" role="button" aria-describedby="lbl1 lbl2">View details
+						&raquo;</a></p>
+				<p id="lbl1">Label 1</p>
+				<p id="lbl2">Label 2</p>
+			</div>
+		</div>
+		<!-- Example row of columns -->
+		<div class="row">
+			<div class="col-md-4">
+				<h2>Heading</h2>
+				<p>Button with text over-ridden by aria-label: </p>
+				<p><a class="btn btn-default" href="#" role="button" aria-label="override">View details &raquo;</a></p>
+			</div>
+			<div class="col-md-4">
+				<h2>Heading</h2>
+				<p>Button with aria-label and one aria-describedby</p>
+				<p><a class="btn btn-default" href="#" role="button" aria-label="override" aria-describedby="lbl1">View
+						details &raquo;</a></p>
+			</div>
+			<div class="col-md-4">
+				<h4>Invalid Subheading</h4>
+				<p>Button with aria-label and two aria-describedby paras</p>
+				<p><a class="btn btn-default" href="#" role="button" aria-label="override"
+						aria-describedby="lbl1 lbl2">View details &raquo;</a></p>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-md-4">
+				<h2>Heading</h2>
+				<p>Button with one aria-labelledby</p>
+				<p><a class="btn btn-default" href="#" role="button" aria-labelledby="lbl1">View details &raquo;</a></p>
+			</div>
+			<div class="col-md-4">
+				<h2>Heading</h2>
+				<p>Button with two aria-labelledby attribs</p>
+				<p><a class="btn btn-default" href="#" role="button" aria-labelledby="lbl1 lbl2">View details
+						&raquo;</a></p>
+			</div>
+			<div class="col-md-4">
+				<h2>Subheading</h2>
+				<p id="lbl3">Label 3</p>
+				<p id="lbl4">Label 4</p>
+				<p>Button with 2 aria-labelledby attribs and 2 aria-describedby attribs</p>
+				<p><a class="btn btn-default" href="#" role="button" aria-labelledby="lbl1 lbl2"
+						aria-describedby="lbl3 lbl4">View details &raquo;</a></p>
+			</div>
+		</div>
 
-        <div class="row">
-            <h1>Invalid h1</h1>
-        </div>
+		<div class="row">
+			<h1>Invalid h1</h1>
+		</div>
 
-        <div class="row">
-            <div class="col-md-4">
-                <h2>Heading</h2>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-            <div class="col-md-4">
-                <h2>Heading</h2>
-                <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-            <div class="col-md-4">
-                <h4>Invalid Subheading</h4>
-                <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
-                <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
-            </div>
-        </div>
+		<div class="row">
+			<div class="col-md-4">
+				<h2>Heading</h2>
+				<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor
+					mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna
+					mollis euismod. Donec sed odio dui. </p>
+				<p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
+			</div>
+			<div class="col-md-4">
+				<h2>Heading</h2>
+				<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor
+					mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna
+					mollis euismod. Donec sed odio dui. </p>
+				<p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
+			</div>
+			<div class="col-md-4">
+				<h4>Invalid Subheading</h4>
+				<p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula
+					porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh,
+					ut fermentum massa justo sit amet risus.</p>
+				<p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
+			</div>
+		</div>
 
-        <hr>
+		<hr>
 
-        <footer>
-            <p>&copy; Company 2014</p>
-        </footer>
-    </div> <!-- /container -->
+		<footer>
+			<p>&copy; Company 2014</p>
+		</footer>
+	</div> <!-- /container -->
 
-    <script src="/webpack-dev-server.js"></script>
-    <script src="/tota11y.js"></script>
+	<script src="/webpack-dev-server.js"></script>
+	<script src="/tota11y.js"></script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -139,7 +139,9 @@
 			</div>
 		</div>
 	</div>
-
+<p>I really love bananas. Next, an empty paragraph! <a href="#"></a></p>
+<p></p>
+<figure><figcaption></figcaption></figure>
 	<div class="container">
 		<div class="row">
 			<div class="col-md-12">
@@ -152,6 +154,7 @@
 				<p id="lbl2">Label 2</p>
 			</div>
 		</div>
+		<nav></nav>
 		<!-- Example row of columns -->
 		<div class="row">
 			<div class="col-md-4">

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,17 @@
 			font-size: 24px;
 			font-weight: bold;
 		}
+
+		.visually-hidden {
+			clip: rect(0 0 0 0);
+			clip-path: inset(50%);
+			height: 1px;
+			overflow: hidden;
+			position: absolute;
+			white-space: nowrap;
+			width: 1px;
+			color: white;
+		}
 	</style>
 	<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
 </head>
@@ -103,7 +114,7 @@
 					<li>
 						<iframe class="github-btn"
 							src="http://ghbtns.com/github-btn.html?user=Khan&amp;repo=tota11y&amp;type=watch&amp;count=true"
-							width="95" height="20" ></iframe>
+							width="95" height="20"></iframe>
 					</li>
 					<li>
 						<iframe class="github-btn"
@@ -113,8 +124,7 @@
 					<li class="follow-btn">
 						<iframe id="twitter-widget-1" scrolling="no" frameborder="0" allowtransparency="true"
 							src="http://platform.twitter.com/widgets/follow_button.53db0107b4b6a3bad3794c3440f5809f.en.html#_=1433768369078&amp;dnt=false&amp;id=twitter-widget-1&amp;lang=en&amp;screen_name=tota11y&amp;show_count=true&amp;show_screen_name=true&amp;size=m"
-							class="twitter-follow-button twitter-follow-button"
-							data-twttr-rendered="true"
+							class="twitter-follow-button twitter-follow-button" data-twttr-rendered="true"
 							style="position: static; visibility: visible; width: 190px; height: 20px;"></iframe>
 					</li>
 					<li class="tweet-btn">
@@ -190,18 +200,16 @@
 		<div class="row">
 			<h1>Invalid h1</h1>
 		</div>
-<ul></ul>
+		<ul></ul>
 		<div class="row">
 			<div class="col-md-4">
-				<h2>Heading</h2>
-				<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor
-					mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna
-					mollis euismod. Donec sed odio dui. </p>
+				<h2 class="visually-hidden">Visually hidden Heading</h2>
+				<p>VISUALLY HIDDEN HEADING ABOVE</p>
 				<p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
 			</div>
 			<div class="col-md-4">
 				<h2>Heading</h2>
-				<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor
+				<p>Donec id <span style="color:bisque">non mi porta gravida at eget metus</span>. Fusce dapibus, tellus ac cursus commodo, tortor
 					mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna
 					mollis euismod. Donec sed odio dui. </p>
 				<p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>

--- a/test/index.html
+++ b/test/index.html
@@ -132,6 +132,7 @@
 		<div class="row">
 			<div class="col-md-12">
 				<h3>Invalid Subheading</h3>
+				<p style="font-size: 25.2px;color: #E03A8E;">Do I have correct contrast?</p>
 				<p>Button describedby two different IDs: </p>
 				<p><a class="btn btn-default" href="#" role="button" aria-describedby="lbl1 lbl2">View details
 						&raquo;</a></p>

--- a/test/index.html
+++ b/test/index.html
@@ -141,6 +141,7 @@
 		<div class="row">
 			<div class="col-md-4">
 				<h2>Heading</h2>
+				<h3></h3>
 				<p>Button with text over-ridden by aria-label: </p>
 				<p><a class="btn btn-default" href="#" role="button" aria-label="override">View details &raquo;</a></p>
 			</div>
@@ -157,6 +158,7 @@
 						aria-describedby="lbl1 lbl2">View details &raquo;</a></p>
 			</div>
 		</div>
+		<ol></ol>
 		<div class="row">
 			<div class="col-md-4">
 				<h2>Heading</h2>
@@ -171,6 +173,7 @@
 			</div>
 			<div class="col-md-4">
 				<h2>Subheading</h2>
+				<li></li>
 				<p id="lbl3">Label 3</p>
 				<p id="lbl4">Label 4</p>
 				<p>Button with 2 aria-labelledby attribs and 2 aria-describedby attribs</p>
@@ -182,7 +185,7 @@
 		<div class="row">
 			<h1>Invalid h1</h1>
 		</div>
-
+<ul></ul>
 		<div class="row">
 			<div class="col-md-4">
 				<h2>Heading</h2>
@@ -200,6 +203,7 @@
 			</div>
 			<div class="col-md-4">
 				<h4>Invalid Subheading</h4>
+				<br><br>
 				<p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula
 					porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh,
 					ut fermentum massa justo sit amet risus.</p>

--- a/test/index.html
+++ b/test/index.html
@@ -96,14 +96,14 @@
 
 			<p><input type="submit" value="value"></p>
 
-			<p><a href="test2.html">Test2</a></p>
+			<p><a title="stupid title ooh SEO" href="test2.html">Test2 wiggle</a></p>
 
 			<div class="social">
 				<ul class="social-buttons">
 					<li>
 						<iframe class="github-btn"
 							src="http://ghbtns.com/github-btn.html?user=Khan&amp;repo=tota11y&amp;type=watch&amp;count=true"
-							width="95" height="20" title="Star on GitHub"></iframe>
+							width="95" height="20" ></iframe>
 					</li>
 					<li>
 						<iframe class="github-btn"
@@ -113,7 +113,7 @@
 					<li class="follow-btn">
 						<iframe id="twitter-widget-1" scrolling="no" frameborder="0" allowtransparency="true"
 							src="http://platform.twitter.com/widgets/follow_button.53db0107b4b6a3bad3794c3440f5809f.en.html#_=1433768369078&amp;dnt=false&amp;id=twitter-widget-1&amp;lang=en&amp;screen_name=tota11y&amp;show_count=true&amp;show_screen_name=true&amp;size=m"
-							class="twitter-follow-button twitter-follow-button" title="Twitter Follow Button"
+							class="twitter-follow-button twitter-follow-button"
 							data-twttr-rendered="true"
 							style="position: static; visibility: visible; width: 190px; height: 20px;"></iframe>
 					</li>
@@ -133,7 +133,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Invalid Subheading</h3>
+				<h3 title="useless title">Invalid Subheading</h3>
 				<p style="font-size: 25.2px;color: #E03A8E;"><b>Do I have correct contrast?</b></p>
 				<p>Button describedby two different IDs: </p>
 				<p><a class="btn btn-default" href="#" role="button" aria-describedby="lbl1 lbl2">View details

--- a/test/index.html
+++ b/test/index.html
@@ -94,6 +94,8 @@
 				</div>
 			</div>
 
+			<p><input type="submit" value="value"></p>
+
 			<div class="social">
 				<ul class="social-buttons">
 					<li>

--- a/test/index.html
+++ b/test/index.html
@@ -96,6 +96,8 @@
 
 			<p><input type="submit" value="value"></p>
 
+			<p><a href="test2.html">Test2</a></p>
+
 			<div class="social">
 				<ul class="social-buttons">
 					<li>
@@ -132,7 +134,7 @@
 		<div class="row">
 			<div class="col-md-12">
 				<h3>Invalid Subheading</h3>
-				<p style="font-size: 25.2px;color: #E03A8E;">Do I have correct contrast?</p>
+				<p style="font-size: 25.2px;color: #E03A8E;"><b>Do I have correct contrast?</b></p>
 				<p>Button describedby two different IDs: </p>
 				<p><a class="btn btn-default" href="#" role="button" aria-describedby="lbl1 lbl2">View details
 						&raquo;</a></p>

--- a/test/test2.html
+++ b/test/test2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Contrast check</title>
+<p style="font-size: 25.2px;color: #E03A8E;">
+	<b>Do I have correct contrast?</b>
+</p>
+
+<script src="/webpack-dev-server.js"></script>
+<script src="/tota11y.js"></script>


### PR DESCRIPTION
- change the name of screenreader wand, which over-promises; added exposure of value attribute on input type=submit fields (as that is what gets exposed and wasn't being reported). Add value of aria-describedby attributes as that is also passed to AT, especially as hints/ instructions on form fields
- stop contrast checker grumbling about transparent  (therefore, invisible) text, eg on Amazon, Guardian). Also text 'visually hidden' using the common clip pattern
- Empty elements plugin: downgrade empty p and multiple br elements to warning (was error), as they may indicate shonky CSS but aren't a disaster for a11y
- Add tests for empty nav, header, main, aside, footer, figcaption. These could be announced to screen reader users (but will be empty) and justifiably make people furiously grumpy.
- When hovering over a tota11y label, max its z-index in case it is obscured by a nearby label in busy pages.
- Make the menu responsive when screen is zoomed to 200%
- New Titles module to show missing titles on iframes (error), and warnings for superfluous titles on other things erroneously put there to placate the false idols of Search Engine Optimists (see The Trials and Tribulations of the Title Attribute)
- Correct calculation of contrast ratio in the contrast module to take account of boldness of text and not just rely on font-size. (Thanks Mozilla dev tools!). Added MPL license.
- New module to highlight empty elements, eg heading and paragraphs, which was a constant bugbear 
Tweaked img/alt module to ask users to check accuracy of alt text (rather than perhaps falsely-reassure that presence of alt text is actually useful)
- Add links to Babylon DNA guidance where applicable
- Split out modules into 'designers'/ content editors and Developers (was 'Experimental')
- New module to expose HTML5 landmarks (footer, header etc) and explicitly set ARIA roles (but not those that are implicit, because that's not as useful for diagnosing coder errors)