### PR TITLE
Specify a background color to pair with foreground

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,6 @@
 body {
     color: #333;
+    background: #fff;
     font: 19px/1.6 "Lato", "Helvetica Neue", Arial, Helvetica, sans-serif;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Hi KA long time no see :)

Based on some [twitter feedback](https://twitter.com/pchampin/status/1400414466982940674) I'd like to submit a one-line CSS change which adds a background instead of relying on browser defaults (since we specify a foreground!)

If a user changes their browser settings (below, firefox settings) to a light foreground and a dark background, the tota11y landing page's fg (#333) will take precedence while the background will persist.

![image](https://user-images.githubusercontent.com/287268/129427493-5955e161-7bf0-48b0-855e-52d6ce167b5e.png)

Before:
![image](https://user-images.githubusercontent.com/287268/129427607-0a3f559a-54f1-4831-8af4-0be1b40a155b.png)

After:
![image](https://user-images.githubusercontent.com/287268/129427623-e2484b88-08e8-4c2c-953b-337ac634ce42.png)

Since #fff is the default background color in most browsers, this change shouldn't have any downstream effects.